### PR TITLE
refactor: implement strategy pattern for client integrations

### DIFF
--- a/src/services/client.service.ts
+++ b/src/services/client.service.ts
@@ -1,389 +1,83 @@
 /**
  * Client service - manages MCP client detection and sync
+ * Facade pattern - delegates all client-specific logic to strategy implementations
  */
 
 import fs from "fs";
-import path from "path";
-import os from "os";
 import { spawnSync } from "child_process";
-import TOML from "@iarna/toml";
 import type {
   ClientId,
   Platform,
-  ClientPathsConfig,
-  ClientNames,
   DetectedClient,
   ClientStatus,
   ClientMcpConfig,
-  ClientServerConfig,
   OperationResult,
 } from "../types/index.js";
 import { getConfigService } from "./config.service.js";
-import { createLogger } from "../shared/logger.js";
-
-const log = createLogger("ClientService");
-
-/** Client configuration paths by platform */
-const CLIENT_PATHS: ClientPathsConfig = {
-  claude: {
-    darwin: path.join(
-      os.homedir(),
-      "Library/Application Support/Claude/claude_desktop_config.json"
-    ),
-    win32: path.join(process.env.APPDATA || "", "Claude/claude_desktop_config.json"),
-    linux: path.join(os.homedir(), ".config/Claude/claude_desktop_config.json"),
-  },
-  cursor: {
-    darwin: path.join(
-      os.homedir(),
-      "Library/Application Support/Cursor/User/globalStorage/cursor.mcp/config.json"
-    ),
-    win32: path.join(process.env.APPDATA || "", "Cursor/User/globalStorage/cursor.mcp/config.json"),
-    linux: path.join(os.homedir(), ".config/Cursor/User/globalStorage/cursor.mcp/config.json"),
-  },
-  windsurf: {
-    darwin: path.join(
-      os.homedir(),
-      "Library/Application Support/Windsurf/User/globalStorage/windsurf.mcp/config.json"
-    ),
-    win32: path.join(
-      process.env.APPDATA || "",
-      "Windsurf/User/globalStorage/windsurf.mcp/config.json"
-    ),
-    linux: path.join(os.homedir(), ".config/Windsurf/User/globalStorage/windsurf.mcp/config.json"),
-  },
-  vscode: {
-    darwin: path.join(os.homedir(), "Library/Application Support/Code/User/mcp.json"),
-    win32: path.join(process.env.APPDATA || "", "Code/User/mcp.json"),
-    linux: path.join(os.homedir(), ".config/Code/User/mcp.json"),
-  },
-  "claude-code": {
-    darwin: path.join(os.homedir(), ".claude.json"),
-    win32: path.join(os.homedir(), ".claude.json"),
-    linux: path.join(os.homedir(), ".claude.json"),
-  },
-  codex: {
-    darwin: path.join(os.homedir(), ".codex/config.toml"),
-    win32: path.join(os.homedir(), ".codex/config.toml"),
-    linux: path.join(os.homedir(), ".codex/config.toml"),
-  },
-  gemini: {
-    darwin: path.join(os.homedir(), ".gemini/settings.json"),
-    win32: path.join(os.homedir(), ".gemini/settings.json"),
-    linux: path.join(os.homedir(), ".gemini/settings.json"),
-  },
-};
-
-const getVscodeAdditionalPath = (): string => {
-  const platform = process.platform as Platform;
-  if (platform === "darwin") {
-    return path.join(os.homedir(), "Library/Application Support/Code/User/mcp.json");
-  }
-  if (platform === "win32") {
-    return path.join(process.env.APPDATA || "", "Code/User/mcp.json");
-  }
-  return path.join(os.homedir(), ".config/Code/User/mcp.json");
-};
-
-/** Additional MCP config paths for real-time loading (per client) */
-const ADDITIONAL_MCP_PATHS: Record<ClientId, string | null> = {
-  cursor: path.join(os.homedir(), ".cursor/mcp.json"),
-  windsurf: path.join(os.homedir(), ".codeium/windsurf/mcp_config.json"),
-  vscode: getVscodeAdditionalPath(),
-  claude: null,
-  "claude-code": null,
-  codex: null,
-  gemini: null,
-};
-
-/** Client display names */
-const CLIENT_NAMES: ClientNames = {
-  claude: "Claude Desktop",
-  cursor: "Cursor",
-  windsurf: "Windsurf",
-  vscode: "VS Code (Continue)",
-  "claude-code": "Claude Code",
-  codex: "Codex CLI",
-  gemini: "Gemini CLI",
-};
+import { getClientStrategy, getRegisteredClientIds, clearStrategyCache } from "./clients/index.js";
 
 /** Client service class */
 export class ClientService {
-  constructor() {
-    // No initialization needed after removing state management
-  }
-
   /** Get current platform */
   private getPlatform(): Platform {
     return process.platform as Platform;
   }
 
-  /** Determine if client config already contains the mcpsm gateway */
-  private hasGateway(config?: ClientMcpConfig | null): boolean {
-    if (!config) return false;
-
-    const gateway = config.mcpServers?.mcpsm || config.servers?.mcpsm;
-    if (!gateway) return false;
-
-    return !!(
-      gateway.command ||
-      gateway.url ||
-      gateway.type ||
-      (gateway.args && gateway.args.length > 0) ||
-      (gateway.env && Object.keys(gateway.env).length > 0)
-    );
-  }
-
   /** Get config path for a client on current platform */
   getClientConfigPath(clientId: ClientId): string | null {
-    const paths = CLIENT_PATHS[clientId];
-    if (!paths) return null;
-    return paths[this.getPlatform()] || null;
+    const strategy = getClientStrategy(clientId);
+    return strategy?.getPrimaryConfigPath(this.getPlatform()) || null;
   }
 
   /** Get client display name */
   getClientName(clientId: ClientId): string {
-    return CLIENT_NAMES[clientId] || clientId;
+    const strategy = getClientStrategy(clientId);
+    return strategy?.metadata.displayName || clientId;
   }
 
   /** Get all supported client IDs */
   getSupportedClients(): ClientId[] {
-    return Object.keys(CLIENT_PATHS) as ClientId[];
+    return getRegisteredClientIds();
   }
 
   /** Check if a client is installed */
   isClientInstalled(clientId: ClientId): boolean {
-    const configPath = this.getClientConfigPath(clientId);
-    if (!configPath) return false;
-
-    // Check if config file exists OR if parent directory exists
-    if (fs.existsSync(configPath)) return true;
-
-    const parentDir = path.dirname(configPath);
-    if (fs.existsSync(parentDir)) return true;
-
-    // For macOS, also check if the Application bundle exists
-    if (process.platform === "darwin") {
-      const appBundles: Record<ClientId, string> = {
-        claude: "/Applications/Claude.app",
-        cursor: "/Applications/Cursor.app",
-        windsurf: "/Applications/Windsurf.app",
-        vscode: "/Applications/Visual Studio Code.app",
-        "claude-code": "/Applications/Claude.app",
-        codex: "/usr/local/bin/codex",
-        gemini: "/usr/local/bin/gemini",
-      };
-
-      const appPath = appBundles[clientId];
-      if (appPath && fs.existsSync(appPath)) return true;
-    }
-
-    return false;
-  }
-
-  /** Read Codex TOML config and convert to standard format */
-  private readCodexConfig(): ClientMcpConfig | null {
-    const configPath = this.getClientConfigPath("codex");
-    if (!configPath || !fs.existsSync(configPath)) return null;
-
-    try {
-      const data = fs.readFileSync(configPath, "utf8");
-      const tomlConfig = TOML.parse(data);
-      const mcpServers: Record<string, ClientServerConfig> = {};
-
-      // Convert mcp_servers from TOML format to standard format
-      const mcpServersToml = tomlConfig.mcp_servers as
-        | Record<string, Record<string, unknown>>
-        | undefined;
-      if (mcpServersToml) {
-        for (const [name, server] of Object.entries(mcpServersToml)) {
-          if (server.command || server.url) {
-            const serverConfig: ClientServerConfig = {};
-
-            if (server.command) {
-              serverConfig.command = server.command as string;
-              serverConfig.args = (server.args as string[]) || [];
-            }
-
-            if (server.url) {
-              serverConfig.url = server.url as string;
-            }
-
-            if (server.type) {
-              serverConfig.type = server.type as string;
-            }
-
-            if (server.env) {
-              serverConfig.env = server.env as Record<string, string>;
-            }
-
-            mcpServers[name] = serverConfig;
-          }
-        }
-      }
-
-      return { mcpServers };
-    } catch (error) {
-      log.debug("Failed to read Codex config:", error);
-      return null;
-    }
-  }
-
-  /** Write Codex config in TOML format */
-  private writeCodexConfig(config: ClientMcpConfig): boolean {
-    const configPath = this.getClientConfigPath("codex");
-    if (!configPath) return false;
-
-    try {
-      const dir = path.dirname(configPath);
-      if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir, { recursive: true });
-      }
-
-      // Read existing config to preserve other settings
-      let existingConfig: TOML.JsonMap = {};
-      if (fs.existsSync(configPath)) {
-        const data = fs.readFileSync(configPath, "utf8");
-        existingConfig = TOML.parse(data);
-      }
-
-      // Convert mcpServers to mcp_servers TOML format
-      const mcpServers: TOML.JsonMap = {};
-      if (config.mcpServers) {
-        for (const [name, server] of Object.entries(config.mcpServers)) {
-          const serverConfig: TOML.JsonMap = {};
-
-          if (server.command) {
-            serverConfig.command = server.command;
-            if (server.args && server.args.length > 0) {
-              serverConfig.args = server.args;
-            }
-          }
-
-          if (server.url) {
-            serverConfig.url = server.url;
-          }
-
-          if (server.type) {
-            serverConfig.type = server.type;
-          }
-
-          if (server.env) {
-            serverConfig.env = server.env;
-          }
-
-          if (Object.keys(serverConfig).length > 0) {
-            mcpServers[name] = serverConfig;
-          }
-        }
-      }
-
-      existingConfig.mcp_servers = mcpServers;
-
-      fs.writeFileSync(configPath, TOML.stringify(existingConfig));
-      return true;
-    } catch (error) {
-      log.debug("Failed to write Codex config:", error);
-      return false;
-    }
+    const strategy = getClientStrategy(clientId);
+    return strategy?.isInstalled(this.getPlatform()) || false;
   }
 
   /** Read client's current config */
   readClientConfig(clientId: ClientId): ClientMcpConfig | null {
-    // Handle TOML-based clients
-    if (clientId === "codex") {
-      return this.readCodexConfig();
-    }
-
-    // For clients with real-time MCP loading, read from the additional MCP path only
-    // This is the source of truth for connection status
-    const additionalMcpPath = ADDITIONAL_MCP_PATHS[clientId];
-    if (additionalMcpPath) {
-      try {
-        if (fs.existsSync(additionalMcpPath)) {
-          const data = fs.readFileSync(additionalMcpPath, "utf8");
-          return JSON.parse(data) as ClientMcpConfig;
-        }
-      } catch (error) {
-        log.debug(`Failed to read additional MCP config from ${additionalMcpPath}:`, error);
-      }
-      return null;
-    }
-
-    // For clients without real-time loading, fall back to primary config
-    const configPath = this.getClientConfigPath(clientId);
-    if (!configPath) return null;
-
-    try {
-      if (fs.existsSync(configPath)) {
-        const data = fs.readFileSync(configPath, "utf8");
-        return JSON.parse(data) as ClientMcpConfig;
-      }
-    } catch (error) {
-      log.debug(`Failed to read ${clientId} config:`, error);
-    }
-
-    return null;
+    const strategy = getClientStrategy(clientId);
+    return strategy?.readConfig() || null;
   }
 
   /** Write client's config */
   writeClientConfig(clientId: ClientId, config: ClientMcpConfig): boolean {
-    // Handle TOML-based clients
-    if (clientId === "codex") {
-      return this.writeCodexConfig(config);
-    }
-
-    const configPath = this.getClientConfigPath(clientId);
-    if (!configPath) return false;
-
-    try {
-      const dir = path.dirname(configPath);
-      if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir, { recursive: true });
-      }
-      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-      return true;
-    } catch (error) {
-      log.debug(`Failed to write ${clientId} config:`, error);
-      return false;
-    }
+    const strategy = getClientStrategy(clientId);
+    return strategy?.writeConfig(config) || false;
   }
 
   /** Detect all installed clients */
   detectClients(): DetectedClient[] {
+    const platform = this.getPlatform();
     const clients: DetectedClient[] = [];
 
     for (const clientId of this.getSupportedClients()) {
-      const configPath = this.getClientConfigPath(clientId);
-      const installed = this.isClientInstalled(clientId);
-      const currentConfig = this.readClientConfig(clientId);
+      const strategy = getClientStrategy(clientId);
+      if (!strategy) continue;
 
-      // Determine connection status
-      let status: ClientStatus;
-      if (!installed) {
-        status = "not-installed";
-      } else {
-        // Check if connected (has mcpsm gateway)
-        const connected = this.hasGateway(currentConfig);
-        status = connected ? "connected" : "disconnected";
-      }
-
-      // Count servers: all servers in config (including mcpsm when connected)
-      let serverCount = 0;
-      if (currentConfig?.mcpServers) {
-        serverCount += Object.keys(currentConfig.mcpServers).length;
-      }
-      if (currentConfig?.servers) {
-        serverCount += Object.keys(currentConfig.servers).length;
-      }
+      const installed = strategy.isInstalled(platform);
+      const status = strategy.getStatus(platform);
+      const serverCount = strategy.getServerCount();
 
       clients.push({
         id: clientId,
-        name: CLIENT_NAMES[clientId] || clientId,
-        configPath,
-        mcpConfigPath: ADDITIONAL_MCP_PATHS[clientId] || null,
+        name: strategy.metadata.displayName,
+        configPath: strategy.getPrimaryConfigPath(platform),
+        mcpConfigPath: strategy.getSecondaryConfigPath(),
         installed,
-        hasConfig: !!currentConfig,
+        hasConfig: strategy.readConfig() !== null,
         status,
         serverCount,
       });
@@ -394,180 +88,35 @@ export class ClientService {
 
   /** Connect servers to a specific client (add mcpsm gateway to client config) */
   connectClient(clientId: ClientId): OperationResult {
-    if (!this.isClientInstalled(clientId)) {
-      return { success: false, error: "Client not installed" };
+    const strategy = getClientStrategy(clientId);
+    if (!strategy) {
+      return { success: false, error: "Unknown client" };
     }
 
     const configService = getConfigService();
     const port = configService.getPort();
 
-    // For clients with real-time MCP loading, use the additional MCP path as source of truth
-    const additionalMcpPath = ADDITIONAL_MCP_PATHS[clientId];
-    if (additionalMcpPath) {
-      try {
-        // Read current config from additional MCP path
-        let clientConfig: ClientMcpConfig = {};
-        if (fs.existsSync(additionalMcpPath)) {
-          try {
-            const data = fs.readFileSync(additionalMcpPath, "utf8");
-            clientConfig = JSON.parse(data) as ClientMcpConfig;
-          } catch (error) {
-            log.debug(`Failed to read additional MCP config from ${additionalMcpPath}:`, error);
-          }
-        }
-
-        // Initialize mcpServers if not present
-        const useServersKey = clientId === "vscode";
-        if (useServersKey) {
-          if (!clientConfig.servers) {
-            clientConfig.servers = {};
-          }
-          clientConfig.servers.mcpsm = {
-            type: "stdio",
-            command: "npx",
-            args: ["-y", "supergateway", "--streamableHttp", `http://localhost:${port}/mcp`],
-          };
-        } else {
-          if (!clientConfig.mcpServers) {
-            clientConfig.mcpServers = {};
-          }
-
-          // Add mcpsm gateway server using supergateway (stdio wrapper for HTTP/SSE)
-          clientConfig.mcpServers.mcpsm = {
-            command: "npx",
-            args: ["-y", "supergateway", "--streamableHttp", `http://localhost:${port}/mcp`],
-          };
-        }
-
-        // Write to additional MCP path only (the source of truth)
-        const dir = path.dirname(additionalMcpPath);
-        if (!fs.existsSync(dir)) {
-          fs.mkdirSync(dir, { recursive: true });
-        }
-        fs.writeFileSync(additionalMcpPath, JSON.stringify(clientConfig, null, 2));
-        return { success: true };
-      } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : "Unknown error";
-        return { success: false, error: `Failed to write config: ${errorMsg}` };
-      }
-    }
-
-    // For clients without real-time loading, use primary config
-    // Use readClientConfig to handle TOML-based clients (like Codex) correctly
-    try {
-      const clientConfig: ClientMcpConfig = this.readClientConfig(clientId) || {};
-
-      if (!clientConfig.mcpServers) {
-        clientConfig.mcpServers = {};
-      }
-
-      clientConfig.mcpServers.mcpsm =
-        clientId === "codex"
-          ? { url: `http://localhost:${port}/mcp` }
-          : {
-              command: "npx",
-              args: ["-y", "supergateway", "--streamableHttp", `http://localhost:${port}/mcp`],
-            };
-
-      const success = this.writeClientConfig(clientId, clientConfig);
-      return {
-        success,
-        error: success ? undefined : "Failed to write config",
-      };
-    } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : "Unknown error";
-      return { success: false, error: `Failed to connect: ${errorMsg}` };
-    }
+    return strategy.connect(port);
   }
 
   /** Disconnect servers from a specific client (remove our servers from client config) */
   disconnectClient(clientId: ClientId): OperationResult {
-    // For clients with real-time MCP loading, use the additional MCP path as source of truth
-    const additionalMcpPath = ADDITIONAL_MCP_PATHS[clientId];
-    if (additionalMcpPath) {
-      try {
-        // Read current config from additional MCP path
-        let currentConfig: ClientMcpConfig | null = null;
-        if (fs.existsSync(additionalMcpPath)) {
-          try {
-            const data = fs.readFileSync(additionalMcpPath, "utf8");
-            currentConfig = JSON.parse(data) as ClientMcpConfig;
-          } catch (error) {
-            log.debug(`Failed to read additional MCP config from ${additionalMcpPath}:`, error);
-          }
-        }
-
-        const useServersKey = clientId === "vscode";
-
-        // If no config or no mcpsm, already disconnected
-        const hasGateway = this.hasGateway(currentConfig);
-
-        if (!currentConfig || !hasGateway) {
-          return { success: true };
-        }
-
-        // Remove mcpsm gateway
-        if (useServersKey && currentConfig.servers) {
-          delete currentConfig.servers.mcpsm;
-        } else if (currentConfig.mcpServers) {
-          delete currentConfig.mcpServers.mcpsm;
-        }
-
-        // Write to additional MCP path only (the source of truth)
-        const dir = path.dirname(additionalMcpPath);
-        if (!fs.existsSync(dir)) {
-          fs.mkdirSync(dir, { recursive: true });
-        }
-        fs.writeFileSync(additionalMcpPath, JSON.stringify(currentConfig, null, 2));
-        return { success: true };
-      } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : "Unknown error";
-        return { success: false, error: `Failed to write config: ${errorMsg}` };
-      }
+    const strategy = getClientStrategy(clientId);
+    if (!strategy) {
+      return { success: false, error: "Unknown client" };
     }
 
-    // For clients without real-time loading, use primary config
-    // Use readClientConfig to handle TOML-based clients (like Codex) correctly
-    try {
-      const currentConfig = this.readClientConfig(clientId);
-
-      const hasGateway = this.hasGateway(currentConfig);
-      if (!currentConfig || !hasGateway) {
-        return { success: true };
-      }
-
-      if (currentConfig.servers?.mcpsm) {
-        delete currentConfig.servers.mcpsm;
-      }
-      if (currentConfig.mcpServers?.mcpsm) {
-        delete currentConfig.mcpServers.mcpsm;
-      }
-
-      const success = this.writeClientConfig(clientId, currentConfig);
-      return {
-        success,
-        error: success ? undefined : "Failed to write config",
-      };
-    } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : "Unknown error";
-      return { success: false, error: `Failed to disconnect: ${errorMsg}` };
-    }
+    return strategy.disconnect();
   }
 
   /** Get connection status for a client */
   getConnectionStatus(clientId: ClientId): ClientStatus {
-    const installed = this.isClientInstalled(clientId);
-    if (!installed) {
+    const strategy = getClientStrategy(clientId);
+    if (!strategy) {
       return "not-installed";
     }
 
-    const currentConfig = this.readClientConfig(clientId);
-
-    if (this.hasGateway(currentConfig)) {
-      return "connected";
-    }
-
-    return "disconnected";
+    return strategy.getStatus(this.getPlatform());
   }
 
   /** Open client config in editor */
@@ -594,7 +143,7 @@ export class ClientService {
 
   /** Check if client exists */
   clientExists(clientId: string): clientId is ClientId {
-    return clientId in CLIENT_PATHS;
+    return getClientStrategy(clientId as ClientId) !== null;
   }
 }
 
@@ -612,6 +161,7 @@ export function getClientService(): ClientService {
 /** Reset the singleton instance (for testing) */
 export function resetClientService(): void {
   instance = null;
+  clearStrategyCache();
 }
 
 export default ClientService;

--- a/src/services/clients/base-client.strategy.ts
+++ b/src/services/clients/base-client.strategy.ts
@@ -1,0 +1,233 @@
+/**
+ * Base Client Strategy - Abstract base class for all client strategies
+ * Provides common functionality and enforces the strategy contract
+ */
+
+import fs from "fs";
+import path from "path";
+import os from "os";
+import type {
+  IClientStrategy,
+  ClientMetadata,
+  ClientCapabilities,
+  ClientPlatformPaths,
+} from "../../types/client-strategy.types.js";
+import type {
+  Platform,
+  ClientMcpConfig,
+  ClientServerConfig,
+  OperationResult,
+  ClientStatus,
+} from "../../types/index.js";
+import { createLogger } from "../../shared/logger.js";
+
+/**
+ * Abstract base class for all client strategies
+ * Provides common functionality and enforces the strategy contract
+ */
+export abstract class BaseClientStrategy implements IClientStrategy {
+  protected readonly log;
+
+  abstract readonly metadata: ClientMetadata;
+  abstract readonly capabilities: ClientCapabilities;
+  abstract readonly paths: ClientPlatformPaths;
+
+  constructor() {
+    this.log = createLogger(this.constructor.name);
+  }
+
+  // === Platform Helpers ===
+
+  protected getPlatform(): Platform {
+    return process.platform as Platform;
+  }
+
+  protected getHomedir(): string {
+    return os.homedir();
+  }
+
+  protected getAppData(): string {
+    return process.env.APPDATA || "";
+  }
+
+  // === Path Resolution ===
+
+  getPrimaryConfigPath(platform: Platform): string | null {
+    return this.paths.primary[platform] || null;
+  }
+
+  getSecondaryConfigPath(): string | null {
+    return this.paths.secondary || null;
+  }
+
+  getEffectiveConfigPath(platform: Platform): string | null {
+    // Real-time clients use secondary path as source of truth
+    if (this.capabilities.hasSecondaryConfigPath && this.paths.secondary) {
+      return this.paths.secondary;
+    }
+    return this.paths.primary[platform] || null;
+  }
+
+  // === Installation Detection ===
+
+  isInstalled(platform: Platform): boolean {
+    const configPath = this.getPrimaryConfigPath(platform);
+    if (!configPath) return false;
+
+    // Check if config file exists
+    if (fs.existsSync(configPath)) return true;
+
+    // Check if parent directory exists
+    const parentDir = path.dirname(configPath);
+    if (fs.existsSync(parentDir)) return true;
+
+    // Check app bundles (macOS)
+    if (platform === "darwin" && this.paths.appBundles?.darwin) {
+      if (fs.existsSync(this.paths.appBundles.darwin)) return true;
+    }
+
+    // Check binary paths (CLI tools)
+    const binaryPath = this.paths.binaryPaths?.[platform];
+    if (binaryPath && fs.existsSync(binaryPath)) return true;
+
+    return false;
+  }
+
+  // === Configuration I/O (Abstract - must be implemented by subclasses) ===
+
+  abstract readConfig(): ClientMcpConfig | null;
+  abstract writeConfig(config: ClientMcpConfig): boolean;
+
+  // === Gateway Management ===
+
+  abstract buildGatewayConfig(port: number): ClientServerConfig;
+
+  hasGateway(config: ClientMcpConfig | null): boolean {
+    if (!config) return false;
+
+    const serversKey = this.capabilities.serversKey;
+    const servers = serversKey === "servers" ? config.servers : config.mcpServers;
+    const gateway = servers?.mcpsm;
+
+    if (!gateway) return false;
+
+    return !!(
+      gateway.command ||
+      gateway.url ||
+      gateway.type ||
+      (gateway.args && gateway.args.length > 0) ||
+      (gateway.env && Object.keys(gateway.env).length > 0)
+    );
+  }
+
+  addGateway(config: ClientMcpConfig, port: number): ClientMcpConfig {
+    const serversKey = this.capabilities.serversKey;
+    const gatewayConfig = this.buildGatewayConfig(port);
+
+    if (serversKey === "servers") {
+      return {
+        ...config,
+        servers: {
+          ...config.servers,
+          mcpsm: gatewayConfig,
+        },
+      };
+    }
+
+    return {
+      ...config,
+      mcpServers: {
+        ...config.mcpServers,
+        mcpsm: gatewayConfig,
+      },
+    };
+  }
+
+  removeGateway(config: ClientMcpConfig): ClientMcpConfig {
+    const serversKey = this.capabilities.serversKey;
+    const result = { ...config };
+
+    if (serversKey === "servers" && result.servers?.mcpsm) {
+      const { mcpsm: _, ...rest } = result.servers;
+      result.servers = rest;
+    } else if (result.mcpServers?.mcpsm) {
+      const { mcpsm: _, ...rest } = result.mcpServers;
+      result.mcpServers = rest;
+    }
+
+    return result;
+  }
+
+  // === High-Level Operations ===
+
+  connect(port: number): OperationResult {
+    const platform = this.getPlatform();
+
+    if (!this.isInstalled(platform)) {
+      return { success: false, error: "Client not installed" };
+    }
+
+    try {
+      let config = this.readConfig() || {};
+      config = this.addGateway(config, port);
+
+      const success = this.writeConfig(config);
+      return {
+        success,
+        error: success ? undefined : "Failed to write config",
+      };
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : "Unknown error";
+      return { success: false, error: `Failed to connect: ${errorMsg}` };
+    }
+  }
+
+  disconnect(): OperationResult {
+    try {
+      const config = this.readConfig();
+
+      if (!config || !this.hasGateway(config)) {
+        return { success: true }; // Already disconnected
+      }
+
+      const updatedConfig = this.removeGateway(config);
+      const success = this.writeConfig(updatedConfig);
+
+      return {
+        success,
+        error: success ? undefined : "Failed to write config",
+      };
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : "Unknown error";
+      return { success: false, error: `Failed to disconnect: ${errorMsg}` };
+    }
+  }
+
+  getStatus(platform: Platform): ClientStatus {
+    if (!this.isInstalled(platform)) {
+      return "not-installed";
+    }
+
+    const config = this.readConfig();
+    return this.hasGateway(config) ? "connected" : "disconnected";
+  }
+
+  getServerCount(): number {
+    const config = this.readConfig();
+    if (!config) return 0;
+
+    let count = 0;
+    if (config.mcpServers) count += Object.keys(config.mcpServers).length;
+    if (config.servers) count += Object.keys(config.servers).length;
+    return count;
+  }
+
+  // === Helper Methods ===
+
+  protected ensureDirectory(filePath: string): void {
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+  }
+}

--- a/src/services/clients/claude-code.strategy.ts
+++ b/src/services/clients/claude-code.strategy.ts
@@ -1,0 +1,38 @@
+/**
+ * Claude Code Strategy - Strategy for Claude Code CLI tool
+ */
+
+import path from "path";
+import { JsonClientStrategy } from "./json-client.strategy.js";
+import type {
+  ClientMetadata,
+  ClientCapabilities,
+  ClientPlatformPaths,
+} from "../../types/client-strategy.types.js";
+
+export class ClaudeCodeStrategy extends JsonClientStrategy {
+  readonly metadata: ClientMetadata = {
+    id: "claude-code",
+    displayName: "Claude Code",
+    description: "Anthropic's Claude Code CLI tool",
+  };
+
+  readonly capabilities: ClientCapabilities = {
+    supportsRealTimeReload: false,
+    hasSecondaryConfigPath: false,
+    configFormat: "json",
+    gatewayType: "stdio",
+    serversKey: "mcpServers",
+  };
+
+  readonly paths: ClientPlatformPaths = {
+    primary: {
+      darwin: path.join(this.getHomedir(), ".claude.json"),
+      win32: path.join(this.getHomedir(), ".claude.json"),
+      linux: path.join(this.getHomedir(), ".claude.json"),
+    },
+    appBundles: {
+      darwin: "/Applications/Claude.app", // Claude Code shares detection with Claude Desktop
+    },
+  };
+}

--- a/src/services/clients/claude.strategy.ts
+++ b/src/services/clients/claude.strategy.ts
@@ -1,0 +1,41 @@
+/**
+ * Claude Desktop Strategy - Strategy for Claude Desktop application
+ */
+
+import path from "path";
+import { JsonClientStrategy } from "./json-client.strategy.js";
+import type {
+  ClientMetadata,
+  ClientCapabilities,
+  ClientPlatformPaths,
+} from "../../types/client-strategy.types.js";
+
+export class ClaudeStrategy extends JsonClientStrategy {
+  readonly metadata: ClientMetadata = {
+    id: "claude",
+    displayName: "Claude Desktop",
+    description: "Anthropic's Claude Desktop application",
+  };
+
+  readonly capabilities: ClientCapabilities = {
+    supportsRealTimeReload: false,
+    hasSecondaryConfigPath: false,
+    configFormat: "json",
+    gatewayType: "stdio",
+    serversKey: "mcpServers",
+  };
+
+  readonly paths: ClientPlatformPaths = {
+    primary: {
+      darwin: path.join(
+        this.getHomedir(),
+        "Library/Application Support/Claude/claude_desktop_config.json"
+      ),
+      win32: path.join(this.getAppData(), "Claude/claude_desktop_config.json"),
+      linux: path.join(this.getHomedir(), ".config/Claude/claude_desktop_config.json"),
+    },
+    appBundles: {
+      darwin: "/Applications/Claude.app",
+    },
+  };
+}

--- a/src/services/clients/codex.strategy.ts
+++ b/src/services/clients/codex.strategy.ts
@@ -1,0 +1,127 @@
+/**
+ * Codex CLI Strategy - Strategy for OpenAI's Codex CLI
+ * Uses TOML config format and URL-only gateway (no supergateway)
+ */
+
+import path from "path";
+import TOML from "@iarna/toml";
+import { TomlClientStrategy } from "./toml-client.strategy.js";
+import type {
+  ClientMetadata,
+  ClientCapabilities,
+  ClientPlatformPaths,
+} from "../../types/client-strategy.types.js";
+import type { ClientMcpConfig, ClientServerConfig } from "../../types/index.js";
+
+export class CodexStrategy extends TomlClientStrategy {
+  readonly metadata: ClientMetadata = {
+    id: "codex",
+    displayName: "Codex CLI",
+    description: "OpenAI's Codex command-line interface",
+  };
+
+  readonly capabilities: ClientCapabilities = {
+    supportsRealTimeReload: false,
+    hasSecondaryConfigPath: false,
+    configFormat: "toml",
+    gatewayType: "url-only",
+    serversKey: "mcpServers",
+  };
+
+  readonly paths: ClientPlatformPaths = {
+    primary: {
+      darwin: path.join(this.getHomedir(), ".codex/config.toml"),
+      win32: path.join(this.getHomedir(), ".codex/config.toml"),
+      linux: path.join(this.getHomedir(), ".codex/config.toml"),
+    },
+    binaryPaths: {
+      darwin: "/usr/local/bin/codex",
+      linux: "/usr/local/bin/codex",
+    },
+  };
+
+  // Override: Codex uses URL-only gateway (no supergateway)
+  buildGatewayConfig(port: number): ClientServerConfig {
+    return {
+      url: `http://localhost:${port}/mcp`,
+    };
+  }
+
+  protected tomlToStandardConfig(tomlConfig: TOML.JsonMap): ClientMcpConfig {
+    const mcpServers: Record<string, ClientServerConfig> = {};
+
+    const mcpServersToml = tomlConfig.mcp_servers as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+
+    if (mcpServersToml) {
+      for (const [name, server] of Object.entries(mcpServersToml)) {
+        if (server.command || server.url) {
+          const serverConfig: ClientServerConfig = {};
+
+          if (server.command) {
+            serverConfig.command = server.command as string;
+            serverConfig.args = (server.args as string[]) || [];
+          }
+
+          if (server.url) {
+            serverConfig.url = server.url as string;
+          }
+
+          if (server.type) {
+            serverConfig.type = server.type as string;
+          }
+
+          if (server.env) {
+            serverConfig.env = server.env as Record<string, string>;
+          }
+
+          mcpServers[name] = serverConfig;
+        }
+      }
+    }
+
+    return { mcpServers };
+  }
+
+  protected standardToTomlConfig(
+    config: ClientMcpConfig,
+    existingConfig: TOML.JsonMap
+  ): TOML.JsonMap {
+    const mcpServers: TOML.JsonMap = {};
+
+    if (config.mcpServers) {
+      for (const [name, server] of Object.entries(config.mcpServers)) {
+        const serverConfig: TOML.JsonMap = {};
+
+        if (server.command) {
+          serverConfig.command = server.command;
+          if (server.args && server.args.length > 0) {
+            serverConfig.args = server.args;
+          }
+        }
+
+        if (server.url) {
+          serverConfig.url = server.url;
+        }
+
+        if (server.type) {
+          serverConfig.type = server.type;
+        }
+
+        if (server.env) {
+          serverConfig.env = server.env;
+        }
+
+        if (Object.keys(serverConfig).length > 0) {
+          mcpServers[name] = serverConfig;
+        }
+      }
+    }
+
+    return {
+      ...existingConfig,
+      mcp_servers: mcpServers,
+    };
+  }
+}

--- a/src/services/clients/cursor.strategy.ts
+++ b/src/services/clients/cursor.strategy.ts
@@ -1,0 +1,46 @@
+/**
+ * Cursor Strategy - Strategy for Cursor IDE
+ * Supports real-time config reloading via secondary config path
+ */
+
+import path from "path";
+import { JsonClientStrategy } from "./json-client.strategy.js";
+import type {
+  ClientMetadata,
+  ClientCapabilities,
+  ClientPlatformPaths,
+} from "../../types/client-strategy.types.js";
+
+export class CursorStrategy extends JsonClientStrategy {
+  readonly metadata: ClientMetadata = {
+    id: "cursor",
+    displayName: "Cursor",
+    description: "AI-powered code editor",
+  };
+
+  readonly capabilities: ClientCapabilities = {
+    supportsRealTimeReload: true,
+    hasSecondaryConfigPath: true,
+    configFormat: "json",
+    gatewayType: "stdio",
+    serversKey: "mcpServers",
+  };
+
+  readonly paths: ClientPlatformPaths = {
+    primary: {
+      darwin: path.join(
+        this.getHomedir(),
+        "Library/Application Support/Cursor/User/globalStorage/cursor.mcp/config.json"
+      ),
+      win32: path.join(this.getAppData(), "Cursor/User/globalStorage/cursor.mcp/config.json"),
+      linux: path.join(
+        this.getHomedir(),
+        ".config/Cursor/User/globalStorage/cursor.mcp/config.json"
+      ),
+    },
+    secondary: path.join(this.getHomedir(), ".cursor/mcp.json"),
+    appBundles: {
+      darwin: "/Applications/Cursor.app",
+    },
+  };
+}

--- a/src/services/clients/gemini.strategy.ts
+++ b/src/services/clients/gemini.strategy.ts
@@ -1,0 +1,39 @@
+/**
+ * Gemini CLI Strategy - Strategy for Google's Gemini CLI
+ */
+
+import path from "path";
+import { JsonClientStrategy } from "./json-client.strategy.js";
+import type {
+  ClientMetadata,
+  ClientCapabilities,
+  ClientPlatformPaths,
+} from "../../types/client-strategy.types.js";
+
+export class GeminiStrategy extends JsonClientStrategy {
+  readonly metadata: ClientMetadata = {
+    id: "gemini",
+    displayName: "Gemini CLI",
+    description: "Google's Gemini command-line interface",
+  };
+
+  readonly capabilities: ClientCapabilities = {
+    supportsRealTimeReload: false,
+    hasSecondaryConfigPath: false,
+    configFormat: "json",
+    gatewayType: "stdio",
+    serversKey: "mcpServers",
+  };
+
+  readonly paths: ClientPlatformPaths = {
+    primary: {
+      darwin: path.join(this.getHomedir(), ".gemini/settings.json"),
+      win32: path.join(this.getHomedir(), ".gemini/settings.json"),
+      linux: path.join(this.getHomedir(), ".gemini/settings.json"),
+    },
+    binaryPaths: {
+      darwin: "/usr/local/bin/gemini",
+      linux: "/usr/local/bin/gemini",
+    },
+  };
+}

--- a/src/services/clients/index.ts
+++ b/src/services/clients/index.ts
@@ -1,0 +1,74 @@
+/**
+ * Client Strategy Registry
+ * Manages client strategy instances and provides factory functions
+ */
+
+import type { ClientId } from "../../types/index.js";
+import type { IClientStrategy } from "../../types/client-strategy.types.js";
+
+// Strategy imports
+import { ClaudeStrategy } from "./claude.strategy.js";
+import { CursorStrategy } from "./cursor.strategy.js";
+import { WindsurfStrategy } from "./windsurf.strategy.js";
+import { VSCodeStrategy } from "./vscode.strategy.js";
+import { ClaudeCodeStrategy } from "./claude-code.strategy.js";
+import { CodexStrategy } from "./codex.strategy.js";
+import { GeminiStrategy } from "./gemini.strategy.js";
+
+/**
+ * Strategy factory - creates strategy instances
+ */
+const strategyFactories: Record<ClientId, () => IClientStrategy> = {
+  claude: () => new ClaudeStrategy(),
+  cursor: () => new CursorStrategy(),
+  windsurf: () => new WindsurfStrategy(),
+  vscode: () => new VSCodeStrategy(),
+  "claude-code": () => new ClaudeCodeStrategy(),
+  codex: () => new CodexStrategy(),
+  gemini: () => new GeminiStrategy(),
+};
+
+/**
+ * Strategy cache - lazy initialization
+ */
+const strategyCache = new Map<ClientId, IClientStrategy>();
+
+/**
+ * Get a strategy instance for a client
+ */
+export function getClientStrategy(clientId: ClientId): IClientStrategy | null {
+  if (!strategyFactories[clientId]) {
+    return null;
+  }
+
+  let strategy = strategyCache.get(clientId);
+  if (!strategy) {
+    strategy = strategyFactories[clientId]();
+    strategyCache.set(clientId, strategy);
+  }
+
+  return strategy;
+}
+
+/**
+ * Get all registered client IDs
+ */
+export function getRegisteredClientIds(): ClientId[] {
+  return Object.keys(strategyFactories) as ClientId[];
+}
+
+/**
+ * Register a new client strategy (for extensibility)
+ */
+export function registerClientStrategy(clientId: string, factory: () => IClientStrategy): void {
+  (strategyFactories as Record<string, () => IClientStrategy>)[clientId] = factory;
+  // Clear cache for this client if it exists
+  strategyCache.delete(clientId as ClientId);
+}
+
+/**
+ * Clear strategy cache (useful for testing)
+ */
+export function clearStrategyCache(): void {
+  strategyCache.clear();
+}

--- a/src/services/clients/json-client.strategy.ts
+++ b/src/services/clients/json-client.strategy.ts
@@ -1,0 +1,54 @@
+/**
+ * JSON Client Strategy - Base class for JSON-based client strategies
+ * Handles JSON config reading/writing
+ */
+
+import fs from "fs";
+import { BaseClientStrategy } from "./base-client.strategy.js";
+import type { ClientMcpConfig, ClientServerConfig } from "../../types/index.js";
+
+/**
+ * Base class for JSON-based client strategies
+ * Handles JSON config reading/writing
+ */
+export abstract class JsonClientStrategy extends BaseClientStrategy {
+  readConfig(): ClientMcpConfig | null {
+    const platform = this.getPlatform();
+    const configPath = this.getEffectiveConfigPath(platform);
+
+    if (!configPath || !fs.existsSync(configPath)) {
+      return null;
+    }
+
+    try {
+      const data = fs.readFileSync(configPath, "utf8");
+      return JSON.parse(data) as ClientMcpConfig;
+    } catch (error) {
+      this.log.debug(`Failed to read config from ${configPath}:`, error);
+      return null;
+    }
+  }
+
+  writeConfig(config: ClientMcpConfig): boolean {
+    const platform = this.getPlatform();
+    const configPath = this.getEffectiveConfigPath(platform);
+
+    if (!configPath) return false;
+
+    try {
+      this.ensureDirectory(configPath);
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      return true;
+    } catch (error) {
+      this.log.debug(`Failed to write config to ${configPath}:`, error);
+      return false;
+    }
+  }
+
+  buildGatewayConfig(port: number): ClientServerConfig {
+    return {
+      command: "npx",
+      args: ["-y", "supergateway", "--streamableHttp", `http://localhost:${port}/mcp`],
+    };
+  }
+}

--- a/src/services/clients/toml-client.strategy.ts
+++ b/src/services/clients/toml-client.strategy.ts
@@ -1,0 +1,72 @@
+/**
+ * TOML Client Strategy - Base class for TOML-based client strategies
+ * Handles TOML config reading/writing with conversion to standard format
+ */
+
+import fs from "fs";
+import TOML from "@iarna/toml";
+import { BaseClientStrategy } from "./base-client.strategy.js";
+import type { ClientMcpConfig } from "../../types/index.js";
+
+/**
+ * Base class for TOML-based client strategies
+ * Handles TOML config reading/writing with conversion to standard format
+ */
+export abstract class TomlClientStrategy extends BaseClientStrategy {
+  readConfig(): ClientMcpConfig | null {
+    const platform = this.getPlatform();
+    const configPath = this.getPrimaryConfigPath(platform);
+
+    if (!configPath || !fs.existsSync(configPath)) {
+      return null;
+    }
+
+    try {
+      const data = fs.readFileSync(configPath, "utf8");
+      const tomlConfig = TOML.parse(data);
+      return this.tomlToStandardConfig(tomlConfig);
+    } catch (error) {
+      this.log.debug(`Failed to read TOML config from ${configPath}:`, error);
+      return null;
+    }
+  }
+
+  writeConfig(config: ClientMcpConfig): boolean {
+    const platform = this.getPlatform();
+    const configPath = this.getPrimaryConfigPath(platform);
+
+    if (!configPath) return false;
+
+    try {
+      this.ensureDirectory(configPath);
+
+      // Read existing config to preserve other settings
+      let existingConfig: TOML.JsonMap = {};
+      if (fs.existsSync(configPath)) {
+        const data = fs.readFileSync(configPath, "utf8");
+        existingConfig = TOML.parse(data);
+      }
+
+      // Convert and merge
+      const tomlConfig = this.standardToTomlConfig(config, existingConfig);
+      fs.writeFileSync(configPath, TOML.stringify(tomlConfig));
+      return true;
+    } catch (error) {
+      this.log.debug(`Failed to write TOML config to ${configPath}:`, error);
+      return false;
+    }
+  }
+
+  /**
+   * Convert TOML config to standard ClientMcpConfig format
+   */
+  protected abstract tomlToStandardConfig(tomlConfig: TOML.JsonMap): ClientMcpConfig;
+
+  /**
+   * Convert standard ClientMcpConfig to TOML format, merging with existing config
+   */
+  protected abstract standardToTomlConfig(
+    config: ClientMcpConfig,
+    existingConfig: TOML.JsonMap
+  ): TOML.JsonMap;
+}

--- a/src/services/clients/vscode.strategy.ts
+++ b/src/services/clients/vscode.strategy.ts
@@ -1,0 +1,55 @@
+/**
+ * VS Code Strategy - Strategy for Visual Studio Code with Continue extension
+ * Uses 'servers' key instead of 'mcpServers'
+ * Supports real-time config reloading
+ */
+
+import path from "path";
+import { JsonClientStrategy } from "./json-client.strategy.js";
+import type {
+  ClientMetadata,
+  ClientCapabilities,
+  ClientPlatformPaths,
+} from "../../types/client-strategy.types.js";
+import type { ClientServerConfig, Platform } from "../../types/index.js";
+
+export class VSCodeStrategy extends JsonClientStrategy {
+  readonly metadata: ClientMetadata = {
+    id: "vscode",
+    displayName: "VS Code (Continue)",
+    description: "Visual Studio Code with Continue extension",
+  };
+
+  readonly capabilities: ClientCapabilities = {
+    supportsRealTimeReload: true,
+    hasSecondaryConfigPath: false, // VS Code uses primary path for real-time loading
+    configFormat: "json",
+    gatewayType: "stdio",
+    serversKey: "servers", // VS Code uses 'servers' not 'mcpServers'
+  };
+
+  readonly paths: ClientPlatformPaths = {
+    primary: {
+      darwin: path.join(this.getHomedir(), "Library/Application Support/Code/User/mcp.json"),
+      win32: path.join(this.getAppData(), "Code/User/mcp.json"),
+      linux: path.join(this.getHomedir(), ".config/Code/User/mcp.json"),
+    },
+    appBundles: {
+      darwin: "/Applications/Visual Studio Code.app",
+    },
+  };
+
+  // Override to include 'type' field required by VS Code
+  buildGatewayConfig(port: number): ClientServerConfig {
+    return {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "supergateway", "--streamableHttp", `http://localhost:${port}/mcp`],
+    };
+  }
+
+  // VS Code uses its primary path for real-time loading (same as primary)
+  getEffectiveConfigPath(platform: Platform): string | null {
+    return this.paths.primary[platform] || null;
+  }
+}

--- a/src/services/clients/windsurf.strategy.ts
+++ b/src/services/clients/windsurf.strategy.ts
@@ -1,0 +1,46 @@
+/**
+ * Windsurf Strategy - Strategy for Windsurf IDE
+ * Supports real-time config reloading via secondary config path
+ */
+
+import path from "path";
+import { JsonClientStrategy } from "./json-client.strategy.js";
+import type {
+  ClientMetadata,
+  ClientCapabilities,
+  ClientPlatformPaths,
+} from "../../types/client-strategy.types.js";
+
+export class WindsurfStrategy extends JsonClientStrategy {
+  readonly metadata: ClientMetadata = {
+    id: "windsurf",
+    displayName: "Windsurf",
+    description: "AI-powered code editor by Codeium",
+  };
+
+  readonly capabilities: ClientCapabilities = {
+    supportsRealTimeReload: true,
+    hasSecondaryConfigPath: true,
+    configFormat: "json",
+    gatewayType: "stdio",
+    serversKey: "mcpServers",
+  };
+
+  readonly paths: ClientPlatformPaths = {
+    primary: {
+      darwin: path.join(
+        this.getHomedir(),
+        "Library/Application Support/Windsurf/User/globalStorage/windsurf.mcp/config.json"
+      ),
+      win32: path.join(this.getAppData(), "Windsurf/User/globalStorage/windsurf.mcp/config.json"),
+      linux: path.join(
+        this.getHomedir(),
+        ".config/Windsurf/User/globalStorage/windsurf.mcp/config.json"
+      ),
+    },
+    secondary: path.join(this.getHomedir(), ".codeium/windsurf/mcp_config.json"),
+    appBundles: {
+      darwin: "/Applications/Windsurf.app",
+    },
+  };
+}

--- a/src/types/client-strategy.types.ts
+++ b/src/types/client-strategy.types.ts
@@ -1,0 +1,164 @@
+/**
+ * Client Strategy Pattern type definitions
+ * Defines the interface and types for client integration strategies
+ */
+
+import type {
+  Platform,
+  ClientMcpConfig,
+  ClientServerConfig,
+  OperationResult,
+  ClientStatus,
+} from "./index.js";
+
+/**
+ * Configuration format types supported by different clients
+ */
+export type ConfigFormat = "json" | "toml";
+
+/**
+ * Gateway connection type - how the client connects to MCPSM
+ */
+export type GatewayType = "stdio" | "url-only";
+
+/**
+ * The key used in the client config for MCP servers
+ */
+export type ServersKey = "mcpServers" | "servers";
+
+/**
+ * Client capability flags
+ */
+export interface ClientCapabilities {
+  /** Whether the client supports real-time config reloading */
+  supportsRealTimeReload: boolean;
+  /** Whether the client has a secondary (real-time) config path */
+  hasSecondaryConfigPath: boolean;
+  /** Config format used by this client */
+  configFormat: ConfigFormat;
+  /** Gateway connection type */
+  gatewayType: GatewayType;
+  /** Key used for servers in config */
+  serversKey: ServersKey;
+}
+
+/**
+ * Platform-specific paths for a client
+ */
+export interface ClientPlatformPaths {
+  /** Primary config path per platform */
+  primary: Partial<Record<Platform, string>>;
+  /** Secondary (real-time) config path, if applicable */
+  secondary?: string | null;
+  /** App bundle paths for installation detection (macOS) */
+  appBundles?: Partial<Record<Platform, string>>;
+  /** Binary paths for CLI tools */
+  binaryPaths?: Partial<Record<Platform, string>>;
+}
+
+/**
+ * Client metadata
+ */
+export interface ClientMetadata {
+  /** Unique client identifier */
+  id: string;
+  /** Human-readable display name */
+  displayName: string;
+  /** Client description */
+  description?: string;
+}
+
+/**
+ * Client Strategy Interface - defines all client-specific behavior
+ */
+export interface IClientStrategy {
+  /** Client metadata */
+  readonly metadata: ClientMetadata;
+
+  /** Client capabilities */
+  readonly capabilities: ClientCapabilities;
+
+  /** Platform paths configuration */
+  readonly paths: ClientPlatformPaths;
+
+  // === Path Resolution ===
+
+  /**
+   * Get the primary config path for the current platform
+   */
+  getPrimaryConfigPath(platform: Platform): string | null;
+
+  /**
+   * Get the secondary (real-time) config path if applicable
+   */
+  getSecondaryConfigPath(): string | null;
+
+  /**
+   * Get the effective config path used for read/write operations
+   * (may be secondary if client supports real-time reload)
+   */
+  getEffectiveConfigPath(platform: Platform): string | null;
+
+  // === Installation Detection ===
+
+  /**
+   * Check if the client is installed on the current platform
+   */
+  isInstalled(platform: Platform): boolean;
+
+  // === Configuration I/O ===
+
+  /**
+   * Read and parse the client's configuration
+   */
+  readConfig(): ClientMcpConfig | null;
+
+  /**
+   * Write configuration back to the client's config file
+   */
+  writeConfig(config: ClientMcpConfig): boolean;
+
+  // === Gateway Management ===
+
+  /**
+   * Build the gateway server configuration for this client
+   */
+  buildGatewayConfig(port: number): ClientServerConfig;
+
+  /**
+   * Check if the gateway is present in the config
+   */
+  hasGateway(config: ClientMcpConfig | null): boolean;
+
+  /**
+   * Add the gateway to the configuration
+   */
+  addGateway(config: ClientMcpConfig, port: number): ClientMcpConfig;
+
+  /**
+   * Remove the gateway from the configuration
+   */
+  removeGateway(config: ClientMcpConfig): ClientMcpConfig;
+
+  // === High-Level Operations ===
+
+  /**
+   * Connect the client to MCPSM
+   */
+  connect(port: number): OperationResult;
+
+  /**
+   * Disconnect the client from MCPSM
+   */
+  disconnect(): OperationResult;
+
+  /**
+   * Get the current connection status
+   */
+  getStatus(platform: Platform): ClientStatus;
+
+  /**
+   * Count servers in the client's config
+   */
+  getServerCount(): number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,6 +44,17 @@ export type {
   OperationResult,
 } from "./client.types.js";
 
+// Client strategy types
+export type {
+  ConfigFormat,
+  GatewayType,
+  ServersKey,
+  ClientCapabilities,
+  ClientPlatformPaths,
+  ClientMetadata,
+  IClientStrategy,
+} from "./client-strategy.types.js";
+
 // Profile types
 export type {
   Profile,


### PR DESCRIPTION
## Summary
- Refactors monolithic ClientService (600+ lines) into strategy pattern
- Creates IClientStrategy interface with individual implementations for all 7 clients
- Adds base classes (BaseClientStrategy, JsonClientStrategy, TomlClientStrategy)
- Reduces ClientService to ~170 lines (72% reduction)

## Changes
- **New files (12):** Strategy interface, base classes, 7 client strategies, registry
- **Modified:** `client.service.ts` (now delegates to strategies), `types/index.ts`

## Adding new clients
```typescript
// 1. Create strategy
export class NewClientStrategy extends JsonClientStrategy { ... }

// 2. Register in src/services/clients/index.ts
strategyFactories["new-client"] = () => new NewClientStrategy();

// 3. Add to ClientId union
```

## Test plan
- [x] All 435 tests pass
- [x] TypeScript compiles without errors
- [x] Lint passes

Closes #18