### PR TITLE
Fix: Improve error messages for HTTP servers returning SSE content

### DIFF
--- a/src/services/testing.service.ts
+++ b/src/services/testing.service.ts
@@ -549,13 +549,16 @@ export class TestingService {
         const decoder = new TextDecoder();
         let buffer = "";
         let parsed: McpToolsResponse | null = null;
+        let rawSSEData = ""; // Store raw SSE response for logging
 
         try {
           while (!parsed) {
             const { value, done } = await reader.read();
             if (done) break;
 
-            buffer += decoder.decode(value, { stream: true });
+            const chunk = decoder.decode(value, { stream: true });
+            buffer += chunk;
+            rawSSEData += chunk; // Accumulate raw data for logging
             const lines = buffer.split("\n");
             buffer = lines.pop() ?? "";
 
@@ -586,8 +589,19 @@ export class TestingService {
           }
         }
 
+        // Log the raw SSE response for debugging
+        log.debug(`Raw SSE response from ${server.name} (${server.type} server):`, {
+          url: server.url,
+          contentType: contentType,
+          rawResponse: rawSSEData,
+          parsed: parsed,
+        });
+
         if (!parsed) {
-          const error = "No JSON data in SSE response";
+          const error =
+            (server.type as string) === "sse"
+              ? "No JSON data in SSE response"
+              : `Server configured as HTTP but returned SSE content without valid JSON data (expected JSON in 'data:' events)`;
           this.updateToolFilter(filterId, [], error);
           return { success: false, error, toolCount: 0 };
         }


### PR DESCRIPTION
## Summary

This PR improves error messages when HTTP servers return SSE content without valid JSON data, making it clearer for users to understand and debug the issue.

### Changes Made

1. **Type-aware error messages**: Distinguish between HTTP and SSE servers in error reporting
   - HTTP servers: `"Server configured as HTTP but returned SSE content without valid JSON data (expected JSON in 'data:' events)"`
   - SSE servers: `"No JSON data in SSE response"` (unchanged)

2. **Debug logging**: Added comprehensive logging of raw SSE responses for troubleshooting
   - Logs server name, URL, content-type, raw response data, and parsed result
   - Helps developers identify formatting issues and authentication problems

### Problem Solved

Previously, when a user configured a server as HTTP (`-t http`) but the server returned SSE content without valid JSON, the error message was confusing:
```
"No JSON data in SSE response"
```

Users would see an SSE error for their HTTP server, causing confusion about the actual issue.

### Solution

The new error message for HTTP servers explicitly states:
- The server is configured as HTTP
- It returned SSE content
- What format is expected (JSON in `data:` events)

This helps users understand they may need to either:
- Change the server type to SSE if appropriate, or
- Fix the server response format

### Testing

- All existing tests pass (435 tests)
- TypeScript compilation successful
- Build completes without errors
- No breaking changes to existing functionality

### Files Changed

- `src/services/testing.service.ts`: Updated error handling and added debug logging