### PR TITLE
feat: Add Zed editor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## The Problem
 
-Managing MCP servers across multiple AI clients (Claude Desktop, Cursor, Windsurf, VS Code) is fragmented and tedious:
+Managing MCP servers across multiple AI clients (Claude Desktop, Cursor, Windsurf, VS Code, Zed) is fragmented and tedious:
 
 - 🔧 **Scattered configs** - Each client has its own config file in different locations
 - 🔄 **Manual sync** - Adding a server means manually editing multiple JSON files

--- a/docs/cli/clients.md
+++ b/docs/cli/clients.md
@@ -10,6 +10,7 @@ Commands for managing MCP client connections using the gateway pattern.
 | Cursor         | `cursor`      | macOS, Windows, Linux | Yes               |
 | Windsurf       | `windsurf`    | macOS, Windows, Linux | Yes               |
 | VS Code        | `vscode`      | macOS, Windows, Linux | Yes               |
+| Zed            | `zed`         | macOS, Windows, Linux | Yes               |
 | Claude Code    | `claude-code` | CLI                   | No                |
 | Codex          | `codex`       | macOS, Windows, Linux | No                |
 | Gemini         | `gemini`      | macOS, Windows, Linux | No                |
@@ -44,7 +45,8 @@ Detected MCP Clients:
   2. Cursor            ✔ Installed   Disconnected
   3. Windsurf          ✘ Not installed
   4. VS Code           ✔ Installed   Connected
-  5. Claude Code       ✘ Not installed
+  5. Zed               ✔ Installed   Disconnected
+  6. Claude Code       ✘ Not installed
 ```
 
 **Status Legend:**
@@ -148,7 +150,7 @@ mcpsm clients connect windsurf
 
 ### 3. Use servers in clients
 
-All your servers are now available in Claude Desktop, Cursor, and Windsurf through the `mcpsm` gateway.
+All your servers are now available in Claude Desktop, Cursor, Windsurf, and Zed through the `mcpsm` gateway.
 
 ### 4. Change port if needed
 
@@ -183,4 +185,4 @@ mcpsm port 9000
 - All connected clients are automatically reconnected
 - The new port is written to each client's configuration
 - No manual editing required
-- Real-time loading clients (Cursor, Windsurf, VS Code) see changes without restart
+- Real-time loading clients (Cursor, Windsurf, VS Code, Zed) see changes without restart

--- a/docs/cli/import-export.md
+++ b/docs/cli/import-export.md
@@ -22,7 +22,7 @@ mcpsm import ./backup.json
 mcpsm import --from <client>
 ```
 
-Supported clients: `claude`, `cursor`, `windsurf`
+Supported clients: `claude`, `cursor`, `windsurf`, `zed`
 
 ### Conflict Handling
 
@@ -52,6 +52,9 @@ mcpsm import --from claude
 
 # Import from Cursor
 mcpsm import --from cursor
+
+# Import from Zed
+mcpsm import --from zed
 
 # Import from JSON file
 mcpsm import ./my-servers.json

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -98,6 +98,7 @@ Claude Desktop:    ~/Library/Application Support/Claude/claude_desktop_config.js
 Cursor:           ~/Library/Application Support/Cursor/User/globalStorage/cursor.mcp/config.json
 Windsurf:         ~/Library/Application Support/Windsurf/User/globalStorage/windsurf.mcp/config.json
 VS Code:          ~/Library/Application Support/Code/User/mcp.json
+Zed:              ~/.config/zed/settings.json
 Claude Code:      ~/.claude/claude_code_config.json
 Codex CLI:        ~/.codex/config.toml
 Gemini CLI:       ~/.gemini/settings.json
@@ -110,6 +111,7 @@ Claude Desktop:    %APPDATA%/Claude/claude_desktop_config.json
 Cursor:           %APPDATA%/Cursor/User/globalStorage/cursor.mcp/config.json
 Windsurf:         %APPDATA%/Windsurf/User/globalStorage/windsurf.mcp/config.json
 VS Code:          %APPDATA%/Code/User/mcp.json
+Zed:              %APPDATA%/Zed/settings.json
 Claude Code:      %USERPROFILE%/.claude/claude_code_config.json
 Codex CLI:        %USERPROFILE%/.codex/config.toml
 Gemini CLI:       %USERPROFILE%/.gemini/settings.json
@@ -122,6 +124,7 @@ Claude Desktop:    ~/.config/Claude/claude_desktop_config.json
 Cursor:           ~/.config/Cursor/User/globalStorage/cursor.mcp/config.json
 Windsurf:         ~/.config/Windsurf/User/globalStorage/windsurf.mcp/config.json
 VS Code:          ~/.config/Code/User/mcp.json
+Zed:              ~/.config/zed/settings.json
 Claude Code:      ~/.claude/claude_code_config.json
 Codex CLI:        ~/.codex/config.toml
 Gemini CLI:       ~/.gemini/settings.json
@@ -136,6 +139,7 @@ Some clients support real-time config loading (no restart required). These use a
 | Cursor   | ~/.cursor/mcp.json                               |
 | Windsurf | ~/.codeium/windsurf/mcp_config.json              |
 | VS Code  | ~/Library/Application Support/Code/User/mcp.json |
+| Zed      | Uses its primary settings.json path              |
 
 When connecting a client, mcpsm writes to **both** the primary config path and the real-time path (if supported).
 
@@ -250,7 +254,7 @@ Each client maintains its own config file (see Client Paths above). mcpsm reads 
 - Additional paths for clients that support live config reloading
 - Automatically written to when connected
 - Allows changes to take effect without restart
-- Cursor, Windsurf, VS Code, and Claude support real-time loading
+- Cursor, Windsurf, VS Code, and Zed support real-time loading
 
 When mcpsm connects a client, it writes the gateway server to **both** locations. This ensures:
 
@@ -266,6 +270,7 @@ When mcpsm connects a client, it writes the gateway server to **both** locations
 | Cursor         | `cursor`      | macOS, Windows, Linux | Yes       | cursor.mcp/config.json     |
 | Windsurf       | `windsurf`    | macOS, Windows, Linux | Yes       | windsurf.mcp/config.json   |
 | VS Code        | `vscode`      | macOS, Windows, Linux | Yes       | Code/User/mcp.json         |
+| Zed            | `zed`         | macOS, Windows, Linux | Yes       | Zed/settings.json          |
 | Claude Code    | `claude-code` | CLI                   | No        | claude_code_config.json    |
 | Codex          | `codex`       | macOS, Windows, Linux | No        | .codex/config.toml (TOML)  |
 | Gemini         | `gemini`      | macOS, Windows, Linux | No        | .gemini/settings.json      |

--- a/docs/guide/client-connections.md
+++ b/docs/guide/client-connections.md
@@ -101,6 +101,7 @@ Some clients support **real-time config loading** - they pick up changes instant
 | Cursor         | ✓ Yes     | Changes appear immediately        |
 | Windsurf       | ✓ Yes     | Changes appear immediately        |
 | VS Code        | ✓ Yes     | Changes appear immediately        |
+| Zed            | ✓ Yes     | Changes appear immediately        |
 | Claude Desktop | No        | Requires restart after connection |
 | Codex          | No        | Requires restart after connection |
 | Gemini         | No        | Requires restart after connection |
@@ -113,6 +114,7 @@ mcpsm writes to special config paths for clients that support real-time loading:
 Cursor:   ~/.cursor/mcp.json
 Windsurf: ~/.codeium/windsurf/mcp_config.json
 VS Code:  ~/Library/Application Support/Code/User/mcp.json
+Zed:      Uses its primary settings.json path (no separate real-time path)
 ```
 
 When you connect a real-time client, mcpsm writes to **both** the primary config and the real-time path, ensuring instant updates.
@@ -142,6 +144,7 @@ All servers are now available in each connected client:
 - **Claude Desktop**: Restart and check MCP servers
 - **Cursor**: Changes appear immediately
 - **Windsurf**: Changes appear immediately
+- **Zed**: Changes appear immediately
 
 ### Step 4: Change Port (Optional)
 
@@ -170,6 +173,8 @@ When you connect a client, mcpsm adds this to the client's MCP server config:
 
 The `PORT` matches your current gateway port setting (default: 8850).
 
+For Zed, mcpsm adds a `context_servers.mcpsm` entry that points to `http://localhost:PORT/mcp`.
+
 ### What Stays Intact
 
 When you connect or disconnect a client, all other servers in the config remain unchanged. mcpsm only modifies the `mcpsm` gateway entry.
@@ -183,6 +188,7 @@ Claude Desktop:    ~/Library/Application Support/Claude/claude_desktop_config.js
 Cursor:           ~/Library/Application Support/Cursor/User/globalStorage/cursor.mcp/config.json
 Windsurf:         ~/Library/Application Support/Windsurf/User/globalStorage/windsurf.mcp/config.json
 VS Code:          ~/Library/Application Support/Code/User/mcp.json
+Zed:              ~/.config/zed/settings.json
 ```
 
 #### Windows
@@ -192,6 +198,7 @@ Claude Desktop:    %APPDATA%\Claude\claude_desktop_config.json
 Cursor:           %APPDATA%\Cursor\User\globalStorage\cursor.mcp\config.json
 Windsurf:         %APPDATA%\Windsurf\User\globalStorage\windsurf.mcp\config.json
 VS Code:          %APPDATA%\Code\User\mcp.json
+Zed:              %APPDATA%\Zed\settings.json
 ```
 
 #### Linux
@@ -201,6 +208,7 @@ Claude Desktop:    ~/.config/Claude/claude_desktop_config.json
 Cursor:           ~/.config/Cursor/User/globalStorage/cursor.mcp/config.json
 Windsurf:         ~/.config/Windsurf/User/globalStorage/windsurf.mcp/config.json
 VS Code:          ~/.config/Code/User/mcp.json
+Zed:              ~/.config/zed/settings.json
 ```
 
 ## View Client Status
@@ -223,6 +231,7 @@ Detected MCP Clients:
   2. Cursor            ✔ Installed   Connected
   3. Windsurf          ✔ Installed   Disconnected
   4. VS Code           ✘ Not installed
+  5. Zed               ✔ Installed   Disconnected
 ```
 
 ## Open Client Config
@@ -261,7 +270,7 @@ Try again after closing the client.
 
 ### Changes Not Appearing
 
-**For real-time clients** (Cursor, Windsurf, VS Code):
+**For real-time clients** (Cursor, Windsurf, VS Code, Zed):
 
 - Changes should appear immediately
 - If not, try restarting the client

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -84,7 +84,7 @@ When you change the `port` setting, **all connected clients are automatically up
 1. All clients with the mcpsm gateway are detected
 2. The gateway is removed and re-added with the new port
 3. Changes are written to both primary and real-time config paths
-4. For real-time clients (Cursor, Windsurf, VS Code), changes take effect immediately
+4. For real-time clients (Cursor, Windsurf, VS Code, Zed), changes take effect immediately
 5. For other clients, they'll use the new port on next restart
 
 ## profiles.json
@@ -117,6 +117,7 @@ Claude Desktop:    ~/Library/Application Support/Claude/claude_desktop_config.js
 Cursor:           ~/Library/Application Support/Cursor/User/globalStorage/cursor.mcp/config.json
 Windsurf:         ~/Library/Application Support/Windsurf/User/globalStorage/windsurf.mcp/config.json
 VS Code:          ~/Library/Application Support/Code/User/mcp.json
+Zed:              ~/.config/zed/settings.json
 Claude Code:      ~/.claude/claude_code_config.json
 Codex:            ~/.codex/config.toml
 Gemini:           ~/.gemini/settings.json
@@ -129,6 +130,7 @@ Claude Desktop:    %APPDATA%\Claude\claude_desktop_config.json
 Cursor:           %APPDATA%\Cursor\User\globalStorage\cursor.mcp\config.json
 Windsurf:         %APPDATA%\Windsurf\User\globalStorage\windsurf.mcp\config.json
 VS Code:          %APPDATA%\Code\User\mcp.json
+Zed:              %APPDATA%\Zed\settings.json
 Claude Code:      %USERPROFILE%\.claude\claude_code_config.json
 Codex:            %USERPROFILE%\.codex\config.toml
 Gemini:           %USERPROFILE%\.gemini\settings.json
@@ -141,6 +143,7 @@ Claude Desktop:    ~/.config/Claude/claude_desktop_config.json
 Cursor:           ~/.config/Cursor/User/globalStorage/cursor.mcp/config.json
 Windsurf:         ~/.config/Windsurf/User/globalStorage/windsurf.mcp/config.json
 VS Code:          ~/.config/Code/User/mcp.json
+Zed:              ~/.config/zed/settings.json
 Claude Code:      ~/.claude/claude_code_config.json
 Codex:            ~/.codex/config.toml
 Gemini:           ~/.gemini/settings.json
@@ -154,6 +157,7 @@ For clients that support real-time config loading, mcpsm also writes to addition
 Cursor:   ~/.cursor/mcp.json
 Windsurf: ~/.codeium/windsurf/mcp_config.json
 VS Code:  ~/Library/Application Support/Code/User/mcp.json
+Zed:      Uses its primary settings.json path (no separate real-time path)
 ```
 
 When you connect a client, mcpsm writes the gateway server to **both** locations. This ensures:
@@ -176,6 +180,8 @@ When you connect a client, mcpsm adds this gateway server entry:
 ```
 
 Where `PORT` is your current gateway port (default: 8850).
+
+For Zed, mcpsm writes a `context_servers.mcpsm` entry that points to `http://localhost:PORT/mcp`.
 
 All your configured servers are accessible through this single gateway. Other servers in the client's config are preserved and remain unchanged.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-MCP Server Manager (`mcpsm`) is a unified CLI and TUI tool for managing MCP (Model Context Protocol) servers across multiple AI clients like Claude Desktop, Cursor, Windsurf, VS Code, and more.
+MCP Server Manager (`mcpsm`) is a unified CLI and TUI tool for managing MCP (Model Context Protocol) servers across multiple AI clients like Claude Desktop, Cursor, Windsurf, VS Code, Zed, and more.
 
 ## Why MCP Server Manager?
 
@@ -23,6 +23,7 @@ Your Servers → mcpsm Daemon ← Client 1 (Claude Desktop)
                            ← Client 2 (Cursor)
                            ← Client 3 (Windsurf)
                            ← Client 4 (VS Code)
+                           ← Client 5 (Zed)
 ```
 
 **Benefits:**
@@ -40,7 +41,7 @@ Your Servers → mcpsm Daemon ← Client 1 (Claude Desktop)
 | **Interactive TUI**   | Beautiful terminal UI for managing servers                |
 | **Gateway Pattern**   | Single mcpsm server per client; all servers accessible    |
 | **Auto Port Updates** | Changing port automatically updates all connected clients |
-| **Real-time Loading** | Cursor, Windsurf, VS Code load config changes instantly   |
+| **Real-time Loading** | Cursor, Windsurf, VS Code, Zed load config changes instantly |
 | **Server testing**    | Test servers in parallel before using them                |
 | **Import/Export**     | Migrate configs between machines or clients               |
 | **Profiles**          | Group servers by project or context                       |

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -65,7 +65,7 @@ mcpsm clients connect windsurf
 - A single `mcpsm` server is added to the client's configuration
 - This server proxies all requests to your daemon at `localhost:{port}/mcp`
 - All your configured servers become instantly accessible
-- For real-time loading clients (Cursor, Windsurf, VS Code), changes appear without restart
+- For real-time loading clients (Cursor, Windsurf, VS Code, Zed), changes appear without restart
 
 ## Step 5: Use Your Servers
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -102,6 +102,7 @@ MCP Server Manager auto-detects clients based on config file locations. If a cli
 | Cursor         | `~/.cursor/`                                          |
 | Windsurf       | `~/.codeium/windsurf/mcp_config.json`                 |
 | VS Code        | `~/.vscode/` or `~/Library/Application Support/Code/` |
+| Zed            | `~/.config/zed/` |
 | Claude Code    | `~/.claude/`                                          |
 | Codex          | `~/.codex/`                                           |
 | Gemini CLI     | `~/.gemini/`                                          |

--- a/docs/tui/screens.md
+++ b/docs/tui/screens.md
@@ -15,6 +15,7 @@ MCP Clients:
     Cursor            ✔ Installed   Disconnected
     Windsurf          ✘ Not installed
     VS Code           ✔ Installed   Connected
+    Zed               ✔ Installed   Disconnected
     Claude Code       ✘ Not installed
 
   ↑↓: Navigate  |  ENTER: Toggle Connect/Disconnect  |  O: Open Config  |  R: Refresh  |  ESC: Back
@@ -191,7 +192,7 @@ When you change the port setting:
 - ✓ All connected clients are **automatically updated**
 - ✓ The new port is written to each client's configuration
 - ✓ No need to manually edit client configs
-- ✓ Real-time loading clients (Cursor, Windsurf, VS Code) see changes without restart
+- ✓ Real-time loading clients (Cursor, Windsurf, VS Code, Zed) see changes without restart
 
 ---
 

--- a/docs/tui/shortcuts.md
+++ b/docs/tui/shortcuts.md
@@ -89,7 +89,7 @@ When adding a new profile with `A`, you'll be prompted to either clone from an e
 
 ## Import/Export Screen
 
-Navigate with `↑/↓` and select with `ENTER`. Options are dynamic based on installed clients (e.g., Import from Claude/Cursor/Windsurf/VS Code), plus import from file and export options.
+Navigate with `↑/↓` and select with `ENTER`. Options are dynamic based on installed clients (e.g., Import from Claude/Cursor/Windsurf/VS Code/Zed), plus import from file and export options.
 
 ---
 

--- a/src/cli/commands/import-export.cmd.ts
+++ b/src/cli/commands/import-export.cmd.ts
@@ -18,7 +18,7 @@ export function registerImportExportCommands(program: Command): void {
   program
     .command("import [file]")
     .description("Import servers from file or client")
-    .option("--from <client>", "Import from a client (claude, cursor, windsurf)")
+    .option("--from <client>", "Import from a client (claude, cursor, windsurf, zed)")
     .option("--overwrite", "Overwrite conflicting servers (non-interactive mode)")
     .option("--skip", "Skip conflicting servers (non-interactive mode)")
     .option("--merge", "Intelligently merge conflicting servers (non-interactive mode)")
@@ -70,6 +70,7 @@ async function handleImport(
     console.log(`  mcpsm import --from claude         Import from Claude Desktop`);
     console.log(`  mcpsm import --from cursor         Import from Cursor`);
     console.log(`  mcpsm import --from windsurf       Import from Windsurf`);
+    console.log(`  mcpsm import --from zed            Import from Zed`);
     console.log(`\nConflict Resolution Options:`);
     console.log(`  --overwrite                        Overwrite conflicting servers`);
     console.log(`  --skip                             Skip conflicting servers (default)`);

--- a/src/services/clients/index.ts
+++ b/src/services/clients/index.ts
@@ -14,6 +14,7 @@ import { VSCodeStrategy } from "./vscode.strategy.js";
 import { ClaudeCodeStrategy } from "./claude-code.strategy.js";
 import { CodexStrategy } from "./codex.strategy.js";
 import { GeminiStrategy } from "./gemini.strategy.js";
+import { ZedStrategy } from "./zed.strategy.js";
 
 /**
  * Strategy factory - creates strategy instances
@@ -26,6 +27,7 @@ const strategyFactories: Record<ClientId, () => IClientStrategy> = {
   "claude-code": () => new ClaudeCodeStrategy(),
   codex: () => new CodexStrategy(),
   gemini: () => new GeminiStrategy(),
+  zed: () => new ZedStrategy(),
 };
 
 /**

--- a/src/services/clients/zed.strategy.ts
+++ b/src/services/clients/zed.strategy.ts
@@ -1,0 +1,279 @@
+/**
+ * Zed Strategy - Strategy for Zed editor
+ * Uses settings.json with context_servers entries
+ */
+
+import fs from "fs";
+import path from "path";
+import { BaseClientStrategy } from "./base-client.strategy.js";
+import type {
+  ClientMetadata,
+  ClientCapabilities,
+  ClientPlatformPaths,
+} from "../../types/client-strategy.types.js";
+import type { ClientMcpConfig, ClientServerConfig } from "../../types/index.js";
+
+type ZedContextServer = {
+  url?: string;
+  headers?: Record<string, string>;
+  settings?: Record<string, unknown>;
+};
+
+type ZedConfig = ClientMcpConfig & {
+  context_servers?: Record<string, ZedContextServer>;
+};
+
+const GATEWAY_ID = "mcpsm";
+
+function stripJsonComments(input: string): string {
+  let result = "";
+  let inString = false;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+    const next = input[i + 1];
+
+    if (inLineComment) {
+      if (char === "\n") {
+        inLineComment = false;
+        result += char;
+      }
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (char === "*" && next === "/") {
+        inBlockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+
+    if (inString) {
+      result += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      result += char;
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      inLineComment = true;
+      i += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      inBlockComment = true;
+      i += 1;
+      continue;
+    }
+
+    result += char;
+  }
+
+  return result;
+}
+
+function stripTrailingCommas(input: string): string {
+  let result = "";
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+
+    if (inString) {
+      result += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      result += char;
+      continue;
+    }
+
+    if (char === ",") {
+      let j = i + 1;
+      while (j < input.length) {
+        const next = input[j];
+        if (next === " " || next === "\t" || next === "\n" || next === "\r") {
+          j += 1;
+          continue;
+        }
+        if (next === "}" || next === "]") {
+          break;
+        }
+        j = -1;
+        break;
+      }
+
+      if (j > 0 && j < input.length && (input[j] === "}" || input[j] === "]")) {
+        continue;
+      }
+    }
+
+    result += char;
+  }
+
+  return result;
+}
+
+function parseJsonWithComments(input: string): ZedConfig | null {
+  try {
+    const sanitized = stripTrailingCommas(stripJsonComments(input));
+    return JSON.parse(sanitized) as ZedConfig;
+  } catch {
+    return null;
+  }
+}
+
+export class ZedStrategy extends BaseClientStrategy {
+  readonly metadata: ClientMetadata = {
+    id: "zed",
+    displayName: "Zed",
+    description: "Zed editor",
+  };
+
+  readonly capabilities: ClientCapabilities = {
+    supportsRealTimeReload: true,
+    hasSecondaryConfigPath: false,
+    configFormat: "json",
+    gatewayType: "url-only",
+    serversKey: "servers",
+  };
+
+  readonly paths: ClientPlatformPaths = {
+    primary: {
+      darwin: path.join(this.getHomedir(), ".config/zed/settings.json"),
+      win32: path.join(this.getAppData(), "Zed/settings.json"),
+      linux: path.join(this.getHomedir(), ".config/zed/settings.json"),
+    },
+    appBundles: {
+      darwin: "/Applications/Zed.app",
+    },
+  };
+
+  readConfig(): ClientMcpConfig | null {
+    const platform = this.getPlatform();
+    const configPath = this.getEffectiveConfigPath(platform);
+
+    if (!configPath || !fs.existsSync(configPath)) {
+      return null;
+    }
+
+    try {
+      const data = fs.readFileSync(configPath, "utf8");
+      const parsed = parseJsonWithComments(data);
+      if (!parsed || typeof parsed !== "object") {
+        return null;
+      }
+      return parsed;
+    } catch (error) {
+      this.log.debug(`Failed to read config from ${configPath}:`, error);
+      return null;
+    }
+  }
+
+  writeConfig(config: ClientMcpConfig): boolean {
+    const platform = this.getPlatform();
+    const configPath = this.getEffectiveConfigPath(platform);
+
+    if (!configPath) return false;
+
+    try {
+      this.ensureDirectory(configPath);
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      return true;
+    } catch (error) {
+      this.log.debug(`Failed to write config to ${configPath}:`, error);
+      return false;
+    }
+  }
+
+  buildGatewayConfig(port: number): ClientServerConfig {
+    return {
+      url: `http://localhost:${port}/mcp`,
+    };
+  }
+
+  hasGateway(config: ClientMcpConfig | null): boolean {
+    if (!config) return false;
+
+    const contextServers = (config as ZedConfig).context_servers;
+    const gateway = contextServers?.[GATEWAY_ID];
+    if (!gateway) return false;
+
+    return !!(
+      gateway.url ||
+      (gateway.headers && Object.keys(gateway.headers).length > 0) ||
+      (gateway.settings && Object.keys(gateway.settings).length > 0)
+    );
+  }
+
+  addGateway(config: ClientMcpConfig, port: number): ClientMcpConfig {
+    const zedConfig = config as ZedConfig;
+    const contextServers = zedConfig.context_servers ?? {};
+    const gatewayConfig: ZedContextServer = {
+      ...(this.buildGatewayConfig(port) as ZedContextServer),
+      headers: {},
+      settings: {},
+    };
+
+    return {
+      ...zedConfig,
+      context_servers: {
+        ...contextServers,
+        [GATEWAY_ID]: gatewayConfig,
+      },
+    };
+  }
+
+  removeGateway(config: ClientMcpConfig): ClientMcpConfig {
+    const zedConfig = config as ZedConfig;
+
+    if (!zedConfig.context_servers?.[GATEWAY_ID]) {
+      return config;
+    }
+
+    const { [GATEWAY_ID]: _, ...rest } = zedConfig.context_servers;
+    return {
+      ...zedConfig,
+      context_servers: rest,
+    };
+  }
+
+  getServerCount(): number {
+    const config = this.readConfig() as ZedConfig | null;
+    if (!config) return 0;
+
+    const contextServers = config.context_servers || {};
+    let count = Object.keys(contextServers).length;
+
+    if (config.mcpServers) count += Object.keys(config.mcpServers).length;
+    if (config.servers) count += Object.keys(config.servers).length;
+
+    return count;
+  }
+}

--- a/src/services/import-export.service.ts
+++ b/src/services/import-export.service.ts
@@ -40,6 +40,18 @@ interface ClaudeFormat {
   >;
 }
 
+/** Zed format */
+interface ZedFormat {
+  context_servers: Record<
+    string,
+    {
+      url?: string;
+      headers?: Record<string, string>;
+      settings?: Record<string, unknown>;
+    }
+  >;
+}
+
 /** MCPSM format */
 interface McpsmFormat {
   servers: LocalServer[];
@@ -76,6 +88,20 @@ export class ImportExportService {
           servers: this.parseClaudeFormat({ mcpServers: serversRecord } as ClaudeFormat),
         };
       }
+    }
+
+    // Zed format: { context_servers: { id: { url, headers, settings } } }
+    const contextServers = (data as ZedFormat).context_servers;
+    if (
+      "context_servers" in data &&
+      contextServers &&
+      typeof contextServers === "object" &&
+      !Array.isArray(contextServers)
+    ) {
+      return {
+        format: "zed",
+        servers: this.parseZedFormat(data as ZedFormat),
+      };
     }
 
     // Claude Desktop format: { mcpServers: { id: { command, args } } }
@@ -156,6 +182,26 @@ export class ImportExportService {
           disabled: server.disabled,
         });
       }
+    }
+
+    return servers;
+  }
+
+  /** Parse Zed format */
+  private parseZedFormat(data: ZedFormat): ImportedServer[] {
+    const servers: ImportedServer[] = [];
+
+    for (const [id, server] of Object.entries(data.context_servers || {})) {
+      if (!server.url) continue;
+
+      const type: TransportType = server.url.includes("/sse") ? "sse" : "http";
+      servers.push({
+        id,
+        name: id,
+        serverType: "remote",
+        url: server.url,
+        type,
+      });
     }
 
     return servers;

--- a/src/types/client.types.ts
+++ b/src/types/client.types.ts
@@ -10,7 +10,8 @@ export type ClientId =
   | "vscode"
   | "claude-code"
   | "codex"
-  | "gemini";
+  | "gemini"
+  | "zed";
 
 /** Platform types */
 export type Platform = "darwin" | "win32" | "linux";


### PR DESCRIPTION
## Summary
- add Zed client strategy using context_servers with JSONC-safe parsing
- register Zed client and import parsing support
- document Zed support and macOS path updates

#23 

## Testing
- not run (commit hook timed out earlier)