### PR TITLE
feat: Add Google Antigravity client support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ Each client has its own config location where the `mcpsm` gateway server is regi
 - **Claude Code**: `~/.claude/claude_code_config.json`
 - **Codex CLI**: `~/.codex/config.toml`
 - **Gemini CLI**: `~/.gemini/settings.json`
+- **Google Antigravity**: `~/.antigravity/mcp_config.json`
 
 ## Important: TUI + CLI Parity
 

--- a/docs/cli/clients.md
+++ b/docs/cli/clients.md
@@ -4,16 +4,17 @@ Commands for managing MCP client connections using the gateway pattern.
 
 ## Supported Clients
 
-| Client         | ID            | Platform              | Real-time Loading |
-| -------------- | ------------- | --------------------- | ----------------- |
-| Claude Desktop | `claude`      | macOS, Windows        | No                |
-| Cursor         | `cursor`      | macOS, Windows, Linux | Yes               |
-| Windsurf       | `windsurf`    | macOS, Windows, Linux | Yes               |
-| VS Code        | `vscode`      | macOS, Windows, Linux | Yes               |
-| Zed            | `zed`         | macOS, Windows, Linux | Yes               |
-| Claude Code    | `claude-code` | CLI                   | No                |
-| Codex          | `codex`       | macOS, Windows, Linux | No                |
-| Gemini         | `gemini`      | macOS, Windows, Linux | No                |
+| Client             | ID            | Platform              | Real-time Loading |
+| ------------------ | ------------- | --------------------- | ----------------- |
+| Claude Desktop     | `claude`      | macOS, Windows        | No                |
+| Cursor             | `cursor`      | macOS, Windows, Linux | Yes               |
+| Windsurf           | `windsurf`    | macOS, Windows, Linux | Yes               |
+| VS Code            | `vscode`      | macOS, Windows, Linux | Yes               |
+| Zed                | `zed`         | macOS, Windows, Linux | Yes               |
+| Claude Code        | `claude-code` | CLI                   | No                |
+| Codex              | `codex`       | macOS, Windows, Linux | No                |
+| Gemini             | `gemini`      | macOS, Windows, Linux | No                |
+| Google Antigravity | `antigravity` | macOS, Windows, Linux | No                |
 
 ---
 

--- a/docs/cli/import-export.md
+++ b/docs/cli/import-export.md
@@ -22,7 +22,7 @@ mcpsm import ./backup.json
 mcpsm import --from <client>
 ```
 
-Supported clients: `claude`, `cursor`, `windsurf`, `zed`
+Supported clients: `claude`, `cursor`, `windsurf`, `zed`, `antigravity`
 
 ### Conflict Handling
 
@@ -55,6 +55,9 @@ mcpsm import --from cursor
 
 # Import from Zed
 mcpsm import --from zed
+
+# Import from Google Antigravity
+mcpsm import --from antigravity
 
 # Import from JSON file
 mcpsm import ./my-servers.json

--- a/docs/guide/client-connections.md
+++ b/docs/guide/client-connections.md
@@ -96,15 +96,16 @@ Each client has a connection state:
 
 Some clients support **real-time config loading** - they pick up changes instantly without restart:
 
-| Client         | Real-Time | Behavior                          |
-| -------------- | --------- | --------------------------------- |
-| Cursor         | ✓ Yes     | Changes appear immediately        |
-| Windsurf       | ✓ Yes     | Changes appear immediately        |
-| VS Code        | ✓ Yes     | Changes appear immediately        |
-| Zed            | ✓ Yes     | Changes appear immediately        |
-| Claude Desktop | No        | Requires restart after connection |
-| Codex          | No        | Requires restart after connection |
-| Gemini         | No        | Requires restart after connection |
+| Client             | Real-Time | Behavior                          |
+| ------------------ | --------- | --------------------------------- |
+| Cursor             | ✓ Yes     | Changes appear immediately        |
+| Windsurf           | ✓ Yes     | Changes appear immediately        |
+| VS Code            | ✓ Yes     | Changes appear immediately        |
+| Zed                | ✓ Yes     | Changes appear immediately        |
+| Claude Desktop     | No        | Requires restart after connection |
+| Codex              | No        | Requires restart after connection |
+| Gemini             | No        | Requires restart after connection |
+| Google Antigravity | No        | Requires restart after connection |
 
 ### Real-Time Config Paths
 
@@ -189,6 +190,7 @@ Cursor:           ~/Library/Application Support/Cursor/User/globalStorage/cursor
 Windsurf:         ~/Library/Application Support/Windsurf/User/globalStorage/windsurf.mcp/config.json
 VS Code:          ~/Library/Application Support/Code/User/mcp.json
 Zed:              ~/.config/zed/settings.json
+Google Antigravity: ~/.antigravity/mcp_config.json
 ```
 
 #### Windows
@@ -199,6 +201,7 @@ Cursor:           %APPDATA%\Cursor\User\globalStorage\cursor.mcp\config.json
 Windsurf:         %APPDATA%\Windsurf\User\globalStorage\windsurf.mcp\config.json
 VS Code:          %APPDATA%\Code\User\mcp.json
 Zed:              %APPDATA%\Zed\settings.json
+Google Antigravity: %USERPROFILE%\.antigravity\mcp_config.json
 ```
 
 #### Linux
@@ -209,6 +212,7 @@ Cursor:           ~/.config/Cursor/User/globalStorage/cursor.mcp/config.json
 Windsurf:         ~/.config/Windsurf/User/globalStorage/windsurf.mcp/config.json
 VS Code:          ~/.config/Code/User/mcp.json
 Zed:              ~/.config/zed/settings.json
+Google Antigravity: ~/.antigravity/mcp_config.json
 ```
 
 ## View Client Status

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-MCP Server Manager (`mcpsm`) is a unified CLI and TUI tool for managing MCP (Model Context Protocol) servers across multiple AI clients like Claude Desktop, Cursor, Windsurf, VS Code, Zed, and more.
+MCP Server Manager (`mcpsm`) is a unified CLI and TUI tool for managing MCP (Model Context Protocol) servers across multiple AI clients like Claude Desktop, Cursor, Windsurf, VS Code, Zed, Google Antigravity, and more.
 
 ## Why MCP Server Manager?
 
@@ -24,6 +24,7 @@ Your Servers → mcpsm Daemon ← Client 1 (Claude Desktop)
                            ← Client 3 (Windsurf)
                            ← Client 4 (VS Code)
                            ← Client 5 (Zed)
+                           ← Client 6 (Google Antigravity)
 ```
 
 **Benefits:**
@@ -36,18 +37,18 @@ Your Servers → mcpsm Daemon ← Client 1 (Claude Desktop)
 
 ## Features
 
-| Feature               | Description                                               |
-| --------------------- | --------------------------------------------------------- |
-| **Interactive TUI**   | Beautiful terminal UI for managing servers                |
-| **Gateway Pattern**   | Single mcpsm server per client; all servers accessible    |
-| **Auto Port Updates** | Changing port automatically updates all connected clients |
+| Feature               | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| **Interactive TUI**   | Beautiful terminal UI for managing servers                   |
+| **Gateway Pattern**   | Single mcpsm server per client; all servers accessible       |
+| **Auto Port Updates** | Changing port automatically updates all connected clients    |
 | **Real-time Loading** | Cursor, Windsurf, VS Code, Zed load config changes instantly |
-| **Server testing**    | Test servers in parallel before using them                |
-| **Import/Export**     | Migrate configs between machines or clients               |
-| **Profiles**          | Group servers by project or context                       |
-| **Daemon mode**       | Run gateway in background with auto-start                 |
-| **OAuth support**     | Built-in OAuth flow with PKCE for remote servers          |
-| **Token counting**    | Track context usage per server and tool                   |
+| **Server testing**    | Test servers in parallel before using them                   |
+| **Import/Export**     | Migrate configs between machines or clients                  |
+| **Profiles**          | Group servers by project or context                          |
+| **Daemon mode**       | Run gateway in background with auto-start                    |
+| **OAuth support**     | Built-in OAuth flow with PKCE for remote servers             |
+| **Token counting**    | Track context usage per server and tool                      |
 
 ## Connection Model
 

--- a/src/services/clients/antigravity.strategy.ts
+++ b/src/services/clients/antigravity.strategy.ts
@@ -1,0 +1,46 @@
+/**
+ * Antigravity Strategy - Strategy for Google Antigravity
+ * Google Antigravity is a tool that uses MCP (Model Context Protocol) servers
+ */
+
+import path from "path";
+import { JsonClientStrategy } from "./json-client.strategy.js";
+import type {
+  ClientMetadata,
+  ClientCapabilities,
+  ClientPlatformPaths,
+} from "../../types/client-strategy.types.js";
+import type { ClientServerConfig } from "../../types/index.js";
+
+export class AntigravityStrategy extends JsonClientStrategy {
+  readonly metadata: ClientMetadata = {
+    id: "antigravity",
+    displayName: "Google Antigravity",
+    description: "Google's AI-powered development tool",
+  };
+
+  readonly capabilities: ClientCapabilities = {
+    supportsRealTimeReload: false,
+    hasSecondaryConfigPath: false,
+    configFormat: "json",
+    gatewayType: "url-only",
+    serversKey: "mcpServers",
+  };
+
+  readonly paths: ClientPlatformPaths = {
+    primary: {
+      darwin: path.join(this.getHomedir(), ".antigravity/mcp_config.json"),
+      win32: path.join(this.getHomedir(), ".antigravity/mcp_config.json"),
+      linux: path.join(this.getHomedir(), ".antigravity/mcp_config.json"),
+    },
+    appBundles: {
+      darwin: "/Applications/Antigravity.app",
+    },
+  };
+
+  buildGatewayConfig(port: number): ClientServerConfig {
+    return {
+      url: `http://localhost:${port}/mcp`,
+    };
+  }
+}

--- a/src/services/clients/index.ts
+++ b/src/services/clients/index.ts
@@ -15,6 +15,7 @@ import { ClaudeCodeStrategy } from "./claude-code.strategy.js";
 import { CodexStrategy } from "./codex.strategy.js";
 import { GeminiStrategy } from "./gemini.strategy.js";
 import { ZedStrategy } from "./zed.strategy.js";
+import { AntigravityStrategy } from "./antigravity.strategy.js";
 
 /**
  * Strategy factory - creates strategy instances
@@ -28,6 +29,7 @@ const strategyFactories: Record<ClientId, () => IClientStrategy> = {
   codex: () => new CodexStrategy(),
   gemini: () => new GeminiStrategy(),
   zed: () => new ZedStrategy(),
+  antigravity: () => new AntigravityStrategy(),
 };
 
 /**

--- a/src/types/client.types.ts
+++ b/src/types/client.types.ts
@@ -11,7 +11,8 @@ export type ClientId =
   | "claude-code"
   | "codex"
   | "gemini"
-  | "zed";
+  | "zed"
+  | "antigravity";
 
 /** Platform types */
 export type Platform = "darwin" | "win32" | "linux";


### PR DESCRIPTION
## Summary

Adds Google Antigravity client support to MCP Server Manager with URL-only configuration format.

## Changes

- **AntigravityStrategy**: New client strategy with URL-only gateway config
- **Config Path**: `~/.antigravity/mcp_config.json`
- **Format**: `{ "mcpServers": { "mcpsm": { "url": "http://localhost:8850/mcp" } } }`
- **No Real-Time Loading**: Requires restart after config changes
- **Full CLI/TUI Support**: Connect, disconnect, import/export

## Usage

```bash
mcpsm clients connect antigravity
mcpsm clients disconnect antigravity
mcpsm import --from antigravity
```

## Testing

- All 435 tests pass
- Configuration format validated
- Port synchronization working

Closes #24