### PR TITLE
Use direct URL gateway for Cursor

### DIFF
--- a/docs/cli/clients.md
+++ b/docs/cli/clients.md
@@ -22,7 +22,7 @@ Commands for managing MCP client connections using the gateway pattern.
 MCP Server Manager uses a **gateway pattern** for client connections:
 
 - A single `mcpsm` server is added to each connected client's configuration
-- This server uses `supergateway` to proxy all MCP requests to the daemon on `localhost:{port}/mcp`
+- This server points to `localhost:{port}/mcp` (via `supergateway` or direct URL, depending on the client)
 - All your configured servers are accessible through this single gateway
 - When the port is changed, all connected clients are automatically updated
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -37,7 +37,7 @@ Instead of syncing individual servers to each client, mcpsm operates as a **gate
 
 1. **Daemon**: Runs a central `mcpsm` server that listens on `localhost:{port}/mcp`
 2. **Client Connection**: Each client connects to the daemon through a single `mcpsm` server entry
-3. **Proxy**: The `mcpsm` server uses `supergateway` to forward all requests to the daemon
+3. **Gateway**: The `mcpsm` server points to the daemon (via `supergateway` or a direct URL, depending on the client)
 4. **All Servers Accessible**: All configured servers are accessible through this single gateway
 
 ### Benefits

--- a/docs/guide/client-connections.md
+++ b/docs/guide/client-connections.md
@@ -44,7 +44,7 @@ mcpsm clients disconnect cursor
 When you connect a client:
 
 1. **Single Gateway Server**: A `mcpsm` server entry is added to your client's configuration
-2. **Proxy Connection**: This server uses `supergateway` to forward requests to `localhost:{port}/mcp`
+2. **Gateway Connection**: The `mcpsm` entry points to `localhost:{port}/mcp` (either via `supergateway` or direct URL, depending on the client)
 3. **All Servers Available**: All your configured servers become accessible through this gateway
 4. **Existing Servers Preserved**: Any servers you already had configured remain untouched
 
@@ -59,8 +59,7 @@ When you run `mcpsm clients connect cursor`, mcpsm:
    ```json
    {
      "mcpsm": {
-       "command": "npx",
-       "args": ["-y", "supergateway", "--streamableHttp", "http://localhost:8850/mcp"]
+       "url": "http://localhost:8850/mcp"
      }
    }
    ```

--- a/src/services/clients/cursor.strategy.ts
+++ b/src/services/clients/cursor.strategy.ts
@@ -10,6 +10,7 @@ import type {
   ClientCapabilities,
   ClientPlatformPaths,
 } from "../../types/client-strategy.types.js";
+import type { ClientServerConfig } from "../../types/index.js";
 
 export class CursorStrategy extends JsonClientStrategy {
   readonly metadata: ClientMetadata = {
@@ -22,7 +23,7 @@ export class CursorStrategy extends JsonClientStrategy {
     supportsRealTimeReload: true,
     hasSecondaryConfigPath: true,
     configFormat: "json",
-    gatewayType: "stdio",
+    gatewayType: "url-only",
     serversKey: "mcpServers",
   };
 
@@ -43,4 +44,11 @@ export class CursorStrategy extends JsonClientStrategy {
       darwin: "/Applications/Cursor.app",
     },
   };
+
+  // Cursor supports direct URL connections without supergateway.
+  buildGatewayConfig(port: number): ClientServerConfig {
+    return {
+      url: `http://localhost:${port}/mcp`,
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- switch Cursor gateway config to a direct URL instead of supergateway
- update docs to describe client-specific URL vs proxy gateway behavior

https://github.com/MateusTorquato/mcp-server-manager/issues/26

## Testing
- npm run typecheck
- npm run build
- npm test