### PR TITLE
Change claude code integration to be url directly

### DIFF
--- a/src/services/clients/claude-code.strategy.ts
+++ b/src/services/clients/claude-code.strategy.ts
@@ -9,6 +9,7 @@ import type {
   ClientCapabilities,
   ClientPlatformPaths,
 } from "../../types/client-strategy.types.js";
+import type { ClientServerConfig } from "../../types/index.js";
 
 export class ClaudeCodeStrategy extends JsonClientStrategy {
   readonly metadata: ClientMetadata = {
@@ -21,7 +22,7 @@ export class ClaudeCodeStrategy extends JsonClientStrategy {
     supportsRealTimeReload: false,
     hasSecondaryConfigPath: false,
     configFormat: "json",
-    gatewayType: "stdio",
+    gatewayType: "url-only",
     serversKey: "mcpServers",
   };
 
@@ -35,4 +36,12 @@ export class ClaudeCodeStrategy extends JsonClientStrategy {
       darwin: "/Applications/Claude.app", // Claude Code shares detection with Claude Desktop
     },
   };
+
+  // Claude Code supports direct HTTP connections without supergateway.
+  buildGatewayConfig(port: number): ClientServerConfig {
+    return {
+      type: "http",
+      url: `http://localhost:${port}/mcp`,
+    };
+  }
 }

--- a/src/types/client-strategy.types.ts
+++ b/src/types/client-strategy.types.ts
@@ -18,6 +18,8 @@ export type ConfigFormat = "json" | "toml";
 
 /**
  * Gateway connection type - how the client connects to MCPSM
+ * - stdio: Uses supergateway (npx -y supergateway --streamableHttp ...)
+ * - url-only: Direct URL/HTTP connection (each strategy defines exact format)
  */
 export type GatewayType = "stdio" | "url-only";
 


### PR DESCRIPTION
Claude Code supports native HTTP MCP connections, so we can remove the supergateway middleware and use a direct HTTP connection with type: "http". This simplifies the configuration and eliminates the npx supergateway dependency.

Closes #29

## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other (describe):

## Related Issues

Fixes #(issue number)

## Checklist

- [ ] I've tested my changes locally
- [ ] I've updated documentation if needed
- [ ] I've added tests for new functionality
- [ ] All tests pass (`npm test`)
- [ ] Linting passes (`npm run lint`)

## Screenshots (if applicable)
