### PR TITLE
Add MCP daemon check

### DIFF
--- a/src/cli/commands/daemon.cmd.ts
+++ b/src/cli/commands/daemon.cmd.ts
@@ -188,7 +188,7 @@ async function handleRefresh(): Promise<void> {
 /** Handle daemon status */
 async function handleStatus(options: { json?: boolean }): Promise<void> {
   const daemonService = getDaemonService();
-  const status = await daemonService.getStatusWithHealth();
+  const status = await daemonService.getStatus();
 
   if (options.json) {
     outputJson(status);

--- a/src/services/daemon.service.ts
+++ b/src/services/daemon.service.ts
@@ -594,32 +594,8 @@ WantedBy=default.target`;
     return { platform: process.platform, supported: false, type: "none" };
   }
 
-  /** Get full status */
-  getStatus(): {
-    running: boolean;
-    pid?: number;
-    startupEnabled: boolean;
-    port: number;
-    logFile: string;
-  } {
-    const configService = getConfigService();
-    const daemonStatus = this.isDaemonRunning();
-
-    return {
-      running: daemonStatus.running,
-      pid: daemonStatus.pid,
-      startupEnabled: this.isStartupEnabled(),
-      port: configService.getPort(),
-      logFile: this.logFile,
-    };
-  }
-
-  /**
-   * Get full status with health check.
-   * This is the recommended method to use for accurate daemon status,
-   * as it verifies the daemon is actually responding via HTTP.
-   */
-  async getStatusWithHealth(): Promise<{
+  /** Get full status with health check */
+  async getStatus(): Promise<{
     running: boolean;
     pid?: number;
     startupEnabled: boolean;

--- a/src/tui/screens/DaemonScreen.tsx
+++ b/src/tui/screens/DaemonScreen.tsx
@@ -39,9 +39,16 @@ interface DaemonState {
   actionResult: { success: boolean; message: string } | null;
   isLoading: boolean;
   logs: string[];
-  healthy: boolean;
-  health?: DaemonHealthResponse;
-  healthLoading: boolean;
+  status: {
+    running: boolean;
+    pid?: number;
+    startupEnabled: boolean;
+    port: number;
+    logFile: string;
+    healthy: boolean;
+    health?: DaemonHealthResponse;
+  } | null;
+  statusLoading: boolean;
 }
 
 export function DaemonScreen({ onBack }: DaemonScreenProps): React.ReactElement {
@@ -54,32 +61,25 @@ export function DaemonScreen({ onBack }: DaemonScreenProps): React.ReactElement 
     actionResult: null,
     isLoading: false,
     logs: [],
-    healthy: false,
-    healthLoading: true,
+    status: null,
+    statusLoading: true,
   });
 
-  // Load health status on mount and after actions
-  const loadHealth = useCallback(async () => {
-    const basicStatus = daemonService.isDaemonRunning();
-    if (!basicStatus.running) {
-      setState((prev) => ({ ...prev, healthy: false, health: undefined, healthLoading: false }));
-      return;
-    }
-
-    setState((prev) => ({ ...prev, healthLoading: true }));
-    const health = await daemonService.checkHealth();
+  // Load status on mount and after actions
+  const loadStatus = useCallback(async () => {
+    setState((prev) => ({ ...prev, statusLoading: true }));
+    const status = await daemonService.getStatus();
     setState((prev) => ({
       ...prev,
-      healthy: health.status === "ok",
-      health,
-      healthLoading: false,
+      status,
+      statusLoading: false,
     }));
   }, [daemonService]);
 
-  // Load health on mount
+  // Load status on mount
   useEffect(() => {
-    loadHealth();
-  }, [loadHealth]);
+    loadStatus();
+  }, [loadStatus]);
 
   // Handle menu option selection
   const handleMenuOption = useCallback(
@@ -107,9 +107,9 @@ export function DaemonScreen({ onBack }: DaemonScreenProps): React.ReactElement 
                 ? { success: true, message: `Daemon started (PID: ${result.pid})` }
                 : { success: false, message: `Failed: ${result.error}` },
             }));
-            // Reload health after starting
+            // Reload status after starting
             if (result.success) {
-              setTimeout(() => loadHealth(), 1000); // Give daemon time to initialize
+              setTimeout(() => loadStatus(), 1000); // Give daemon time to initialize
             }
           }
           break;
@@ -134,9 +134,9 @@ export function DaemonScreen({ onBack }: DaemonScreenProps): React.ReactElement 
                 ? { success: true, message: "Daemon stopped" }
                 : { success: false, message: `Failed: ${result.error}` },
             }));
-            // Reload health after stopping
+            // Reload status after stopping
             if (result.success) {
-              loadHealth();
+              loadStatus();
             }
           }
           break;
@@ -153,9 +153,9 @@ export function DaemonScreen({ onBack }: DaemonScreenProps): React.ReactElement 
               ? { success: true, message: "Daemon refreshed" }
               : { success: false, message: `Failed: ${result.error}` },
           }));
-          // Reload health after refreshing
+          // Reload status after refreshing
           if (result.success) {
-            setTimeout(() => loadHealth(), 500);
+            setTimeout(() => loadStatus(), 500);
           }
           break;
         }
@@ -220,7 +220,7 @@ export function DaemonScreen({ onBack }: DaemonScreenProps): React.ReactElement 
         }
       }
     },
-    [daemonService, loadHealth]
+    [daemonService, loadStatus]
   );
 
   // Handle keyboard input
@@ -267,8 +267,7 @@ export function DaemonScreen({ onBack }: DaemonScreenProps): React.ReactElement 
     }
   });
 
-  const { currentIndex, view, actionResult, isLoading, logs, healthy, health, healthLoading } = state;
-  const status = daemonService.getStatus();
+  const { currentIndex, view, actionResult, isLoading, logs, status, statusLoading } = state;
 
   const daemonMenuSections = createMenuSections({
     actions: [{ key: "Enter", label: "Select" }],
@@ -336,23 +335,18 @@ export function DaemonScreen({ onBack }: DaemonScreenProps): React.ReactElement 
 
   // Helper function to render health status
   const renderHealthStatus = (): React.ReactElement => {
+    if (statusLoading || !status) {
+      return <Text dimColor>Loading...</Text>;
+    }
+
     if (!status.running) {
       return <Text color="red">● Stopped</Text>;
     }
 
-    if (healthLoading) {
-      return (
-        <Box gap={1}>
-          <Text color="yellow">● Running (PID: {status.pid})</Text>
-          <Text dimColor>checking health...</Text>
-        </Box>
-      );
-    }
-
-    if (healthy && health) {
+    if (status.healthy) {
       return (
         <Text color="green">
-          ● Healthy (PID: {status.pid}, {health.servers} servers, {health.tools} tools)
+          ● Healthy (PID: {status.pid}, {status.health?.servers ?? 0} servers, {status.health?.tools ?? 0} tools)
         </Text>
       );
     }
@@ -361,7 +355,7 @@ export function DaemonScreen({ onBack }: DaemonScreenProps): React.ReactElement 
     return (
       <Box gap={1}>
         <Text color="yellow">● Running but unhealthy (PID: {status.pid})</Text>
-        <Text color="red">{health?.error || "Not responding"}</Text>
+        <Text color="red">{status.health?.error || "Not responding"}</Text>
       </Box>
     );
   };
@@ -375,11 +369,11 @@ export function DaemonScreen({ onBack }: DaemonScreenProps): React.ReactElement 
         {renderHealthStatus()}
         <Text dimColor>|</Text>
         <Text>Port:</Text>
-        <Text color={theme.colors.primary}>{status.port}</Text>
+        <Text color={theme.colors.primary}>{status?.port ?? "..."}</Text>
         <Text dimColor>|</Text>
         <Text>Auto-start:</Text>
-        <Text color={status.startupEnabled ? "green" : "gray"}>
-          {status.startupEnabled ? "enabled" : "disabled"}
+        <Text color={status?.startupEnabled ? "green" : "gray"}>
+          {status?.startupEnabled ? "enabled" : "disabled"}
         </Text>
       </Box>
 

--- a/src/tui/screens/ProfilesScreen.tsx
+++ b/src/tui/screens/ProfilesScreen.tsx
@@ -229,7 +229,7 @@ export function ProfilesScreen({ onBack }: ProfilesScreenProps): React.ReactElem
 
           // Refresh daemon to load new profile's servers
           const daemonService = getDaemonService();
-          const statusResult = daemonService.getStatus();
+          const statusResult = daemonService.isDaemonRunning();
           if (statusResult.running) {
             daemonService.refreshDaemon().then((refreshResult) => {
               if (refreshResult.success) {

--- a/tests/tui/screens/DaemonScreen.test.tsx
+++ b/tests/tui/screens/DaemonScreen.test.tsx
@@ -33,8 +33,10 @@ describe("DaemonScreen", () => {
       expect(lastFrame()).toContain("Status");
     });
 
-    it("should display port information", () => {
+    it("should display port information", async () => {
       const { lastFrame } = render(<DaemonScreen onBack={mockOnBack} />);
+
+      await waitForStateUpdate();
 
       expect(lastFrame()).toContain("Port");
       expect(lastFrame()).toContain("8850");
@@ -153,25 +155,31 @@ describe("DaemonScreen", () => {
   });
 
   describe("Status Display", () => {
-    it("should show 'not running' when daemon is stopped", () => {
+    it("should show 'stopped' when daemon is not running", async () => {
       const { lastFrame } = render(<DaemonScreen onBack={mockOnBack} />);
 
-      expect(lastFrame()).toMatch(/not running|stopped|inactive/i);
+      await waitForStateUpdate();
+
+      expect(lastFrame()).toMatch(/stopped/i);
     });
 
-    it("should show 'running' when daemon is active", () => {
+    it("should show 'healthy' when daemon is running and responding", async () => {
       // Update mock to return running state
-      mockDaemonService.getStatus.mockReturnValueOnce({
+      mockDaemonService.getStatus.mockResolvedValueOnce({
         running: true,
         pid: 12345,
         port: 8850,
         startupEnabled: false,
         logFile: path.join(os.tmpdir(), "daemon.log"),
+        healthy: true,
+        health: { status: "ok", servers: 2, tools: 5 },
       });
 
       const { lastFrame } = render(<DaemonScreen onBack={mockOnBack} />);
 
-      expect(lastFrame()).toMatch(/running|active/i);
+      await waitForStateUpdate();
+
+      expect(lastFrame()).toMatch(/healthy/i);
     });
   });
 

--- a/tests/tui/setup.ts
+++ b/tests/tui/setup.ts
@@ -129,14 +129,18 @@ export const mockSettingsService = {
 
 // Mock daemon service
 export const mockDaemonService = {
-  getStatus: vi.fn(() => ({
-    running: false,
-    pid: null,
-    port: 8850,
-    startupEnabled: false,
-    logFile: "/tmp/daemon.log",
-  })),
+  getStatus: vi.fn(() =>
+    Promise.resolve({
+      running: false,
+      pid: null,
+      port: 8850,
+      startupEnabled: false,
+      logFile: "/tmp/daemon.log",
+      healthy: false,
+    })
+  ),
   isDaemonRunning: vi.fn(() => ({ running: false, pid: null })),
+  checkHealth: vi.fn(() => Promise.resolve({ status: "ok", servers: 0, tools: 0 })),
   refreshDaemon: vi.fn(() => Promise.resolve({ success: true })),
   startDaemon: vi.fn(() => ({ success: true, pid: 12345 })),
   stopDaemon: vi.fn(() => ({ success: true })),


### PR DESCRIPTION
…sive daemons

The daemon status was only checking if a process with the stored PID exists, but not verifying the daemon's HTTP server is actually responding. This caused issues where the UI would show the daemon as "running" when it was actually unresponsive.

Changes:
- Add checkHealth() method to DaemonService that calls /health endpoint
- Add getStatusWithHealth() async method for accurate daemon status
- Update CLI daemon status to show health info (servers, tools count)
- Update TUI DaemonScreen to display health status with real-time updates
- Show "Running but unhealthy" state when process is alive but not responding

Fixes #30

## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other (describe):

## Related Issues

Fixes #(issue number)

## Checklist

- [ ] I've tested my changes locally
- [ ] I've updated documentation if needed
- [ ] I've added tests for new functionality
- [ ] All tests pass (`npm test`)
- [ ] Linting passes (`npm run lint`)

## Screenshots (if applicable)
