### PR TITLE
Add support to opencode

### DIFF
--- a/src/services/clients/base-client.strategy.ts
+++ b/src/services/clients/base-client.strategy.ts
@@ -106,7 +106,14 @@ export abstract class BaseClientStrategy implements IClientStrategy {
     if (!config) return false;
 
     const serversKey = this.capabilities.serversKey;
-    const servers = serversKey === "servers" ? config.servers : config.mcpServers;
+    let servers: Record<string, ClientServerConfig> | undefined;
+    if (serversKey === "servers") {
+      servers = config.servers;
+    } else if (serversKey === "mcp") {
+      servers = config.mcp;
+    } else {
+      servers = config.mcpServers;
+    }
     const gateway = servers?.mcpsm;
 
     if (!gateway) return false;
@@ -134,6 +141,16 @@ export abstract class BaseClientStrategy implements IClientStrategy {
       };
     }
 
+    if (serversKey === "mcp") {
+      return {
+        ...config,
+        mcp: {
+          ...config.mcp,
+          mcpsm: gatewayConfig,
+        },
+      };
+    }
+
     return {
       ...config,
       mcpServers: {
@@ -150,6 +167,9 @@ export abstract class BaseClientStrategy implements IClientStrategy {
     if (serversKey === "servers" && result.servers?.mcpsm) {
       const { mcpsm: _, ...rest } = result.servers;
       result.servers = rest;
+    } else if (serversKey === "mcp" && result.mcp?.mcpsm) {
+      const { mcpsm: _, ...rest } = result.mcp;
+      result.mcp = rest;
     } else if (result.mcpServers?.mcpsm) {
       const { mcpsm: _, ...rest } = result.mcpServers;
       result.mcpServers = rest;
@@ -219,6 +239,7 @@ export abstract class BaseClientStrategy implements IClientStrategy {
     let count = 0;
     if (config.mcpServers) count += Object.keys(config.mcpServers).length;
     if (config.servers) count += Object.keys(config.servers).length;
+    if (config.mcp) count += Object.keys(config.mcp).length;
     return count;
   }
 

--- a/src/services/clients/index.ts
+++ b/src/services/clients/index.ts
@@ -16,6 +16,7 @@ import { CodexStrategy } from "./codex.strategy.js";
 import { GeminiStrategy } from "./gemini.strategy.js";
 import { ZedStrategy } from "./zed.strategy.js";
 import { AntigravityStrategy } from "./antigravity.strategy.js";
+import { OpenCodeStrategy } from "./opencode.strategy.js";
 
 /**
  * Strategy factory - creates strategy instances
@@ -30,6 +31,7 @@ const strategyFactories: Record<ClientId, () => IClientStrategy> = {
   gemini: () => new GeminiStrategy(),
   zed: () => new ZedStrategy(),
   antigravity: () => new AntigravityStrategy(),
+  opencode: () => new OpenCodeStrategy(),
 };
 
 /**

--- a/src/services/clients/opencode.strategy.ts
+++ b/src/services/clients/opencode.strategy.ts
@@ -1,0 +1,145 @@
+/**
+ * OpenCode Strategy - Strategy for OpenCode CLI
+ * OpenCode uses 'mcp' key for servers and has multiple possible config locations
+ */
+
+import fs from "fs";
+import path from "path";
+import { JsonClientStrategy } from "./json-client.strategy.js";
+import type {
+  ClientMetadata,
+  ClientCapabilities,
+  ClientPlatformPaths,
+} from "../../types/client-strategy.types.js";
+import type { ClientMcpConfig, Platform } from "../../types/index.js";
+
+export class OpenCodeStrategy extends JsonClientStrategy {
+  readonly metadata: ClientMetadata = {
+    id: "opencode",
+    displayName: "OpenCode",
+    description: "OpenCode AI agent CLI",
+  };
+
+  readonly capabilities: ClientCapabilities = {
+    supportsRealTimeReload: false,
+    hasSecondaryConfigPath: false,
+    configFormat: "json",
+    gatewayType: "stdio",
+    serversKey: "mcp",
+  };
+
+  readonly paths: ClientPlatformPaths = {
+    // Primary path is the first location to check: $HOME/.opencode.json
+    primary: {
+      darwin: path.join(this.getHomedir(), ".opencode.json"),
+      win32: path.join(this.getHomedir(), ".opencode.json"),
+      linux: path.join(this.getHomedir(), ".opencode.json"),
+    },
+    binaryPaths: {
+      darwin: "/usr/local/bin/opencode",
+      linux: "/usr/local/bin/opencode",
+    },
+  };
+
+  /**
+   * Get all possible config paths in search order:
+   * 1. $HOME/.opencode.json
+   * 2. $XDG_CONFIG_HOME/opencode/.opencode.json
+   * 3. $HOME/.config/opencode/.opencode.json
+   */
+  private getConfigSearchPaths(): string[] {
+    const homedir = this.getHomedir();
+    const xdgConfigHome = process.env.XDG_CONFIG_HOME || path.join(homedir, ".config");
+
+    return [
+      path.join(homedir, ".opencode.json"),
+      path.join(xdgConfigHome, "opencode", ".opencode.json"),
+      path.join(homedir, ".config", "opencode", ".opencode.json"),
+    ];
+  }
+
+  /**
+   * Find the first existing config file path
+   */
+  private findExistingConfigPath(): string | null {
+    for (const configPath of this.getConfigSearchPaths()) {
+      if (fs.existsSync(configPath)) {
+        return configPath;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get the path to use for writing config
+   * Uses existing path if found, otherwise uses primary path
+   */
+  private getWriteConfigPath(): string {
+    const existingPath = this.findExistingConfigPath();
+    if (existingPath) {
+      return existingPath;
+    }
+    // Default to primary path ($HOME/.opencode.json)
+    return this.getConfigSearchPaths()[0];
+  }
+
+  /**
+   * Override isInstalled to check all possible config locations
+   */
+  isInstalled(platform: Platform): boolean {
+    // Check if any config file exists
+    if (this.findExistingConfigPath()) return true;
+
+    // Check parent directories for any of the config locations
+    for (const configPath of this.getConfigSearchPaths()) {
+      const parentDir = path.dirname(configPath);
+      if (fs.existsSync(parentDir)) {
+        // For the home directory config, just check if home exists
+        if (configPath === this.getConfigSearchPaths()[0]) {
+          return true;
+        }
+      }
+    }
+
+    // Check binary paths
+    const binaryPath = this.paths.binaryPaths?.[platform];
+    if (binaryPath && fs.existsSync(binaryPath)) return true;
+
+    return false;
+  }
+
+  /**
+   * Override readConfig to check all possible config locations
+   */
+  readConfig(): ClientMcpConfig | null {
+    const configPath = this.findExistingConfigPath();
+
+    if (!configPath) {
+      return null;
+    }
+
+    try {
+      const data = fs.readFileSync(configPath, "utf8");
+      return JSON.parse(data) as ClientMcpConfig;
+    } catch (error) {
+      this.log.debug(`Failed to read config from ${configPath}:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Override writeConfig to use appropriate config location
+   */
+  writeConfig(config: ClientMcpConfig): boolean {
+    const configPath = this.getWriteConfigPath();
+
+    try {
+      this.ensureDirectory(configPath);
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      return true;
+    } catch (error) {
+      this.log.debug(`Failed to write config to ${configPath}:`, error);
+      return false;
+    }
+  }
+}

--- a/src/types/client-strategy.types.ts
+++ b/src/types/client-strategy.types.ts
@@ -24,7 +24,7 @@ export type GatewayType = "stdio" | "url-only";
 /**
  * The key used in the client config for MCP servers
  */
-export type ServersKey = "mcpServers" | "servers";
+export type ServersKey = "mcpServers" | "servers" | "mcp";
 
 /**
  * Client capability flags

--- a/src/types/client.types.ts
+++ b/src/types/client.types.ts
@@ -12,7 +12,8 @@ export type ClientId =
   | "codex"
   | "gemini"
   | "zed"
-  | "antigravity";
+  | "antigravity"
+  | "opencode";
 
 /** Platform types */
 export type Platform = "darwin" | "win32" | "linux";
@@ -62,6 +63,7 @@ export interface ClientServerConfig {
 export interface ClientMcpConfig {
   mcpServers?: Record<string, ClientServerConfig>;
   servers?: Record<string, ClientServerConfig>;
+  mcp?: Record<string, ClientServerConfig>;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
Implements support for OpenCode CLI as a new client. OpenCode uses a different configuration format with 'mcp' key for servers instead of 'mcpServers' or 'servers'.

Changes:
- Add 'opencode' to ClientId type
- Add 'mcp' to ServersKey type and ClientMcpConfig interface
- Update base strategy methods to handle 'mcp' server key
- Create OpenCodeStrategy with multi-path config file discovery:
  - $HOME/.opencode.json
  - $XDG_CONFIG_HOME/opencode/.opencode.json
  - $HOME/.config/opencode/.opencode.json
- Register OpenCode strategy in client registry

Closes #28