### PR TITLE
Isolate profiles with embedded servers and fix Space key

### DIFF
--- a/src/cli/commands/daemon.cmd.ts
+++ b/src/cli/commands/daemon.cmd.ts
@@ -109,17 +109,19 @@ async function handleStart(
       console.error(`${colors.red}Error: Profile '${options.profile}' not found${colors.reset}`);
       process.exit(1);
     }
-    selectedServers = profileData.servers || [];
-    const includesAll =
-      selectedServers.length === 0 && (profileData.remoteServers || []).length === 0;
-    if (selectedServers.length === 0 && !includesAll) {
+    const localIds = (profileData.servers || []).map((s) => (typeof s === "string" ? s : s.id));
+    const remoteIds = (profileData.remoteServers || []).map((s) =>
+      typeof s === "string" ? s : s.id
+    );
+    selectedServers = [...localIds, ...remoteIds];
+    if (selectedServers.length === 0) {
       console.error(
         `${colors.red}Error: Profile '${options.profile}' has no servers${colors.reset}`
       );
       process.exit(1);
     }
     console.log(
-      `${colors.gray}Using profile '${options.profile}' with ${selectedServers.length || "all"} server(s)${colors.reset}`
+      `${colors.gray}Using profile '${options.profile}' with ${selectedServers.length} server(s)${colors.reset}`
     );
   } else if (serverNames.length > 0) {
     // Validate server names

--- a/src/cli/commands/profile.cmd.ts
+++ b/src/cli/commands/profile.cmd.ts
@@ -29,9 +29,7 @@ export function registerProfileCommands(program: Command): void {
 
       for (const p of profiles) {
         const active = p.isActive ? ` ${colors.green}(active)${colors.reset}` : "";
-        const servers = p.includesAll
-          ? `${colors.gray}all servers${colors.reset}`
-          : `${p.serverCount} server(s)`;
+        const servers = `${p.serverCount} server(s)`;
 
         console.log(`  ${colors.cyan}${p.id}${colors.reset} - ${p.name}${active}`);
         console.log(`    ${servers}`);
@@ -96,38 +94,6 @@ export function registerProfileCommands(program: Command): void {
 
       if (result.success) {
         console.log(`${c.checkmark} Switched to profile '${name}'`);
-      } else {
-        console.log(`${c.cross} ${result.error}`);
-        process.exit(1);
-      }
-    });
-
-  // Add server to profile
-  profile
-    .command("add <profile> <server>")
-    .description("Add a server to a profile")
-    .action(async (profileId: string, serverId: string) => {
-      const profileService = getProfileService();
-      const result = profileService.addServer(profileId, serverId);
-
-      if (result.success) {
-        console.log(`${c.checkmark} Server '${serverId}' added to profile '${profileId}'`);
-      } else {
-        console.log(`${c.cross} ${result.error}`);
-        process.exit(1);
-      }
-    });
-
-  // Remove server from profile
-  profile
-    .command("remove <profile> <server>")
-    .description("Remove a server from a profile")
-    .action(async (profileId: string, serverId: string) => {
-      const profileService = getProfileService();
-      const result = profileService.removeServer(profileId, serverId);
-
-      if (result.success) {
-        console.log(`${c.checkmark} Server '${serverId}' removed from profile '${profileId}'`);
       } else {
         console.log(`${c.cross} ${result.error}`);
         process.exit(1);

--- a/src/cli/commands/server.cmd.ts
+++ b/src/cli/commands/server.cmd.ts
@@ -10,6 +10,7 @@ import { getConfigService } from "../../services/config.service.js";
 import { getTestingService } from "../../services/testing.service.js";
 import { getAuthService } from "../../services/auth.service.js";
 import { getDaemonService } from "../../services/daemon.service.js";
+import { getProfileService } from "../../services/profile.service.js";
 import type { LocalServer, RemoteServer, TransportType, OAuthConfig } from "../../types/index.js";
 import { redactServerForOutput } from "../../shared/redaction.js";
 
@@ -209,6 +210,7 @@ export function registerServerCommands(program: Command): void {
           process.exit(1);
         }
 
+        getProfileService().syncFromConfig();
         console.log(`${c.checkmark} Server '${name}' added successfully!`);
 
         // Test if --test flag provided
@@ -278,6 +280,7 @@ export function registerServerCommands(program: Command): void {
           process.exit(1);
         }
 
+        getProfileService().syncFromConfig();
         console.log(`${c.checkmark} Server '${name}' added successfully!`);
 
         // Test if --test flag provided
@@ -380,6 +383,7 @@ export function registerServerCommands(program: Command): void {
 
       const deleteResult = configService.deleteServer(server.id);
       if (deleteResult.success) {
+        getProfileService().syncFromConfig();
         console.log(`${c.checkmark} Server '${server.name}' deleted`);
       } else {
         console.log(`${c.cross} ${deleteResult.error}`);
@@ -440,6 +444,7 @@ export function registerServerCommands(program: Command): void {
 
         const updateResult = configService.updateLocalServer(server.id, updates);
         if (updateResult.success) {
+          getProfileService().syncFromConfig();
           console.log(`${c.checkmark} Server '${server.name}' updated`);
         } else {
           console.log(`${c.cross} ${updateResult.error}`);
@@ -493,6 +498,7 @@ export function registerServerCommands(program: Command): void {
 
         const updateResult = configService.updateRemoteServer(server.id, updates);
         if (updateResult.success) {
+          getProfileService().syncFromConfig();
           console.log(`${c.checkmark} Server '${server.name}' updated`);
 
           if (updates.oauth?.enabled === true && !remoteServer.oauth?.enabled) {
@@ -533,6 +539,7 @@ export function registerServerCommands(program: Command): void {
 
       const enableResult = configService.enableServer(server.id);
       if (enableResult.success) {
+        getProfileService().syncFromConfig();
         console.log(`${c.checkmark} Server '${server.name}' enabled`);
         refreshDaemonIfRunning("enabling server");
       } else {
@@ -573,6 +580,7 @@ export function registerServerCommands(program: Command): void {
 
       const disableResult = configService.disableServer(server.id);
       if (disableResult.success) {
+        getProfileService().syncFromConfig();
         console.log(`${c.checkmark} Server '${server.name}' disabled`);
         refreshDaemonIfRunning("disabling server");
       } else {

--- a/src/services/gateway.service.ts
+++ b/src/services/gateway.service.ts
@@ -603,7 +603,7 @@ export async function startGateway(
       const mcpMatch = parsedUrl.pathname.match(/^\/mcp(?:\/([a-zA-Z0-9_-]+))?$/);
 
       if (mcpMatch) {
-        const profileId = mcpMatch[1] || "default";
+        const profileId = mcpMatch[1] || getProfileService().getActiveProfileId();
 
         // Validate profile exists when specified
         if (profileId && !gatewayState.profileViews.has(profileId)) {

--- a/src/services/gateway.service.ts
+++ b/src/services/gateway.service.ts
@@ -354,12 +354,14 @@ function buildProfileView(profileId: string): ProfileView | null {
   if (!profile) return null;
 
   // Build the set of server IDs this profile includes.
-  // Empty arrays = include all connected servers (backwards compat).
-  const includesAll = profile.servers.length === 0 && profile.remoteServers.length === 0;
-
-  const profileServerIds = includesAll
-    ? null // null = match everything
-    : new Set<string>([...profile.servers, ...profile.remoteServers.map((id) => `remote:${id}`)]);
+  const localIds = profile.servers.map((s) => (typeof s === "string" ? s : s.id));
+  const remoteIds = profile.remoteServers.map((s) =>
+    typeof s === "string" ? s : `remote:${typeof s === "string" ? s : s.id}`
+  );
+  const profileServerIds =
+    localIds.length === 0 && remoteIds.length === 0
+      ? null // null = match everything (empty profile)
+      : new Set<string>([...localIds, ...remoteIds]);
 
   const tools: Tool[] = [];
   const toolMap = new Map<string, string>();
@@ -379,7 +381,7 @@ function buildProfileView(profileId: string): ProfileView | null {
   }
 
   logger.debug(
-    `Profile '${profileId}': ${tools.length} tool(s) from ${includesAll ? "all" : (profileServerIds?.size ?? 0)} server(s)`
+    `Profile '${profileId}': ${tools.length} tool(s) from ${profileServerIds ? profileServerIds.size : "all"} server(s)`
   );
 
   return { profileId, toolToServerMap: toolMap, aggregatedTools: tools };
@@ -511,8 +513,9 @@ export async function startGateway(
     for (const profileItem of profileService.list()) {
       const profile = profileService.getProfile(profileItem.id);
       if (!profile) continue;
-      for (const id of profile.servers) serverIdsToStart.add(id);
-      for (const id of profile.remoteServers) serverIdsToStart.add(`remote:${id}`);
+      for (const s of profile.servers) serverIdsToStart.add(typeof s === "string" ? s : s.id);
+      for (const s of profile.remoteServers)
+        serverIdsToStart.add(`remote:${typeof s === "string" ? s : s.id}`);
     }
 
     // Filter servers to only those in the start set
@@ -839,8 +842,9 @@ export async function refreshGateway(
     for (const profileItem of profileService.list()) {
       const profile = profileService.getProfile(profileItem.id);
       if (!profile) continue;
-      for (const id of profile.servers) serverIdsToStart.add(id);
-      for (const id of profile.remoteServers) serverIdsToStart.add(`remote:${id}`);
+      for (const s of profile.servers) serverIdsToStart.add(typeof s === "string" ? s : s.id);
+      for (const s of profile.remoteServers)
+        serverIdsToStart.add(`remote:${typeof s === "string" ? s : s.id}`);
     }
 
     const localServers = configService

--- a/src/services/profile.service.ts
+++ b/src/services/profile.service.ts
@@ -1,5 +1,9 @@
 /**
  * Profile service - manages server profiles
+ *
+ * Each profile owns its own embedded server objects.
+ * When switching profiles, the profile's servers are loaded into config.json.
+ * After any server mutation, syncFromConfig() copies config.json servers back into the active profile.
  */
 
 import fs from "fs";
@@ -8,7 +12,8 @@ import type {
   ProfilesConfig,
   ProfileListItem,
   ProfileResult,
-  ProfileServers,
+  LocalServer,
+  RemoteServer,
 } from "../types/index.js";
 import { getConfigService } from "./config.service.js";
 import { createLogger } from "../shared/logger.js";
@@ -36,6 +41,7 @@ export class ProfileService {
     const configService = getConfigService();
     this.profilesPath = configService.getPaths().profilesPath;
     this.profiles = this.load();
+    this.migrateIfNeeded();
   }
 
   /** Load profiles from file */
@@ -50,6 +56,42 @@ export class ProfileService {
       log.debug("Failed to load profiles, using defaults:", error);
     }
     return { ...DEFAULT_PROFILES };
+  }
+
+  /** Migrate old string-ID profiles to embedded server objects */
+  private migrateIfNeeded(): void {
+    const configService = getConfigService();
+    let changed = false;
+
+    for (const [_id, profile] of Object.entries(this.profiles.profiles)) {
+      // Detect old format: servers array contains strings instead of objects
+      if (profile.servers.length > 0 && typeof profile.servers[0] === "string") {
+        const serverIds = profile.servers as unknown as string[];
+        const remoteIds = profile.remoteServers as unknown as string[];
+        profile.servers = configService
+          .getLocalServers()
+          .filter((s) => serverIds.includes(s.id))
+          .map((s) => ({ ...s }));
+        profile.remoteServers = configService
+          .getRemoteServers()
+          .filter((s) => remoteIds.includes(s.id))
+          .map((s) => ({ ...s }));
+        changed = true;
+      } else if (profile.servers.length === 0 && profile.remoteServers.length === 0) {
+        // Old "include all" semantic — populate from config.json
+        const localServers = configService.getLocalServers();
+        const remoteServers = configService.getRemoteServers();
+        if (localServers.length > 0 || remoteServers.length > 0) {
+          profile.servers = localServers.map((s) => ({ ...s }));
+          profile.remoteServers = remoteServers.map((s) => ({ ...s }));
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) {
+      this.save();
+    }
   }
 
   /** Save profiles to file */
@@ -79,11 +121,10 @@ export class ProfileService {
       name: profile.name,
       serverCount: profile.servers.length + profile.remoteServers.length,
       isActive: id === this.profiles.activeProfile,
-      includesAll: profile.servers.length === 0 && profile.remoteServers.length === 0,
     }));
   }
 
-  /** Create a new profile */
+  /** Create a new profile (starts with no servers) */
   create(id: string, name?: string): ProfileResult {
     if (this.profiles.profiles[id]) {
       return { success: false, error: "Profile already exists" };
@@ -99,7 +140,7 @@ export class ProfileService {
     return { success: true };
   }
 
-  /** Clone a profile */
+  /** Clone a profile (deep copies server objects) */
   clone(sourceId: string, newId: string, newName?: string): ProfileResult {
     const source = this.profiles.profiles[sourceId];
     if (!source) {
@@ -110,11 +151,10 @@ export class ProfileService {
       return { success: false, error: "Profile already exists" };
     }
 
-    // Deep clone the profile
     this.profiles.profiles[newId] = {
       name: newName || `${source.name} (Copy)`,
-      servers: [...source.servers],
-      remoteServers: [...source.remoteServers],
+      servers: JSON.parse(JSON.stringify(source.servers)),
+      remoteServers: JSON.parse(JSON.stringify(source.remoteServers)),
       toolFilters: source.toolFilters ? JSON.parse(JSON.stringify(source.toolFilters)) : undefined,
     };
 
@@ -138,73 +178,46 @@ export class ProfileService {
     return { success: true };
   }
 
-  /** Switch to a profile */
+  /** Switch to a profile — loads profile's servers into config.json */
   use(id: string): ProfileResult {
     if (!this.profiles.profiles[id]) {
       return { success: false, error: "Profile not found" };
     }
 
+    // Save current config into the currently active profile before switching
+    this.syncFromConfig();
+
     this.profiles.activeProfile = id;
     this.save();
-    return { success: true };
-  }
 
-  /** Add server to profile */
-  addServer(profileId: string, serverId: string): ProfileResult {
-    const profile = this.profiles.profiles[profileId];
-    if (!profile) {
-      return { success: false, error: "Profile not found" };
-    }
-
+    // Load the new profile's servers into config.json
+    const profile = this.profiles.profiles[id];
     const configService = getConfigService();
-    const serverResult = configService.findServer(serverId);
+    const config = configService.getConfig();
+    config.servers = JSON.parse(JSON.stringify(profile.servers));
+    config.remoteServers = JSON.parse(JSON.stringify(profile.remoteServers));
+    configService.saveConfig();
+    configService.reload();
 
-    if (!serverResult) {
-      return { success: false, error: "Server not found" };
-    }
-
-    if (serverResult.type === "local") {
-      if (!profile.servers.includes(serverId)) {
-        profile.servers.push(serverId);
-      }
-    } else {
-      if (!profile.remoteServers.includes(serverId)) {
-        profile.remoteServers.push(serverId);
-      }
-    }
-
-    this.save();
     return { success: true };
   }
 
-  /** Remove server from profile */
-  removeServer(profileId: string, serverId: string): ProfileResult {
-    const profile = this.profiles.profiles[profileId];
-    if (!profile) {
-      return { success: false, error: "Profile not found" };
-    }
-
-    profile.servers = profile.servers.filter((id) => id !== serverId);
-    profile.remoteServers = profile.remoteServers.filter((id) => id !== serverId);
-
-    this.save();
-    return { success: true };
-  }
-
-  /** Get servers for active profile */
-  getServersForActiveProfile(): ProfileServers {
-    const configService = getConfigService();
+  /** Sync current config.json servers into the active profile */
+  syncFromConfig(): void {
     const profile = this.getActiveProfile();
+    if (!profile) return;
 
+    const configService = getConfigService();
+    profile.servers = configService.getLocalServers().map((s) => ({ ...s }));
+    profile.remoteServers = configService.getRemoteServers().map((s) => ({ ...s }));
+    this.save();
+  }
+
+  /** Get servers for active profile (returns the embedded arrays directly) */
+  getServersForActiveProfile(): { servers: LocalServer[]; remoteServers: RemoteServer[] } {
+    const profile = this.getActiveProfile();
     if (!profile) {
-      return {
-        servers: configService.getLocalServers(),
-        remoteServers: configService.getRemoteServers(),
-      };
-    }
-
-    // Empty arrays mean "include all"
-    if (profile.servers.length === 0 && profile.remoteServers.length === 0) {
+      const configService = getConfigService();
       return {
         servers: configService.getLocalServers(),
         remoteServers: configService.getRemoteServers(),
@@ -212,35 +225,23 @@ export class ProfileService {
     }
 
     return {
-      servers: configService.getLocalServers().filter((s) => profile.servers.includes(s.id)),
-      remoteServers: configService
-        .getRemoteServers()
-        .filter((s) => profile.remoteServers.includes(s.id)),
+      servers: profile.servers,
+      remoteServers: profile.remoteServers,
     };
   }
 
   /** Get servers for a specific profile */
-  getServersForProfile(profileId: string): ProfileServers | null {
+  getServersForProfile(
+    profileId: string
+  ): { servers: LocalServer[]; remoteServers: RemoteServer[] } | null {
     const profile = this.getProfile(profileId);
     if (!profile) {
       return null;
     }
 
-    const configService = getConfigService();
-
-    // Empty arrays mean "include all"
-    if (profile.servers.length === 0 && profile.remoteServers.length === 0) {
-      return {
-        servers: configService.getLocalServers(),
-        remoteServers: configService.getRemoteServers(),
-      };
-    }
-
     return {
-      servers: configService.getLocalServers().filter((s) => profile.servers.includes(s.id)),
-      remoteServers: configService
-        .getRemoteServers()
-        .filter((s) => profile.remoteServers.includes(s.id)),
+      servers: profile.servers,
+      remoteServers: profile.remoteServers,
     };
   }
 
@@ -254,17 +255,6 @@ export class ProfileService {
     profile.name = newName;
     this.save();
     return { success: true };
-  }
-
-  /** Convert "include all" profile to explicit server lists */
-  makeExplicit(profileId: string): void {
-    const profile = this.profiles.profiles[profileId];
-    if (!profile) return;
-    if (profile.servers.length > 0 || profile.remoteServers.length > 0) return;
-    const configService = getConfigService();
-    profile.servers = configService.getLocalServers().map((s) => s.id);
-    profile.remoteServers = configService.getRemoteServers().map((s) => s.id);
-    this.save();
   }
 
   /** Reload profiles from disk */

--- a/src/shared/features.ts
+++ b/src/shared/features.ts
@@ -173,22 +173,6 @@ export const FEATURES: Feature[] = [
     requiredInTui: true,
   },
   {
-    id: "profiles-add-server",
-    name: "Add server to profile",
-    category: "profiles",
-    cliCommands: ["profile add"],
-    tuiImplementation: "ProfilesScreen.tsx",
-    requiredInTui: true,
-  },
-  {
-    id: "profiles-remove-server",
-    name: "Remove server from profile",
-    category: "profiles",
-    cliCommands: ["profile remove"],
-    tuiImplementation: "ProfilesScreen.tsx",
-    requiredInTui: true,
-  },
-  {
     id: "profiles-rename",
     name: "Rename profile",
     category: "profiles",

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -616,7 +616,6 @@ export function App({ onExit }: AppProps): React.ReactElement {
           : configService.disableServer(server.id);
 
         if (result.success) {
-          showMessage(`${server.disabled ? "Enabled" : "Disabled"} '${server.name}'`, "success");
           profileService.syncFromConfig();
           refreshServers();
           refreshDaemonIfRunning("toggling server");
@@ -981,7 +980,7 @@ export function App({ onExit }: AppProps): React.ReactElement {
                         <Box key={id} gap={1} paddingX={1}>
                           <Text color={arrowColor}>{isCurrent ? "→" : " "}</Text>
                           <Text color={isDisabled ? theme.colors.warning : theme.colors.serverCheckEnabled}>
-                            {isDisabled ? "[○]" : "[✓]"}
+                            {isDisabled ? "[ ]" : "[✓]"}
                           </Text>
                           <Text color={nameColor} bold={isCurrent}>
                             {server.name || server.id}

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -350,6 +350,7 @@ export function App({ onExit }: AppProps): React.ReactElement {
 
   // Navigate back to main screen
   const goBack = useCallback(() => {
+    profileService.syncFromConfig();
     refreshServers();
     refreshAuthStatus();
     setState((prev) => ({
@@ -389,7 +390,7 @@ export function App({ onExit }: AppProps): React.ReactElement {
 
       if (result.success) {
         showMessage(`Server '${server.name}' deleted`, "success");
-        // Refresh daemon if running (auto-sync)
+        profileService.syncFromConfig();
         refreshDaemonIfRunning("deleting server");
         
         // Get fresh server lists after deletion - create new arrays to ensure React detects the change
@@ -555,10 +556,14 @@ export function App({ onExit }: AppProps): React.ReactElement {
       if (key.leftArrow) {
         const profiles = profileService.list();
         if (profiles.length > 1) {
-          setState((prev) => {
-            const prevIdx = prev.currentProfileIndex > 0 ? prev.currentProfileIndex - 1 : profiles.length - 1;
-            return { ...prev, currentProfileIndex: prevIdx };
-          });
+          const prevIdx = state.currentProfileIndex > 0 ? state.currentProfileIndex - 1 : profiles.length - 1;
+          const targetProfile = profiles[prevIdx];
+          if (targetProfile) {
+            profileService.use(targetProfile.id);
+            refreshServers();
+            setState((prev) => ({ ...prev, currentProfileIndex: prevIdx, currentIndex: 0 }));
+            refreshDaemonIfRunning("switching profile");
+          }
         }
         return;
       }
@@ -567,10 +572,14 @@ export function App({ onExit }: AppProps): React.ReactElement {
       if (key.rightArrow) {
         const profiles = profileService.list();
         if (profiles.length > 1) {
-          setState((prev) => {
-            const nextIdx = prev.currentProfileIndex < profiles.length - 1 ? prev.currentProfileIndex + 1 : 0;
-            return { ...prev, currentProfileIndex: nextIdx };
-          });
+          const nextIdx = state.currentProfileIndex < profiles.length - 1 ? state.currentProfileIndex + 1 : 0;
+          const targetProfile = profiles[nextIdx];
+          if (targetProfile) {
+            profileService.use(targetProfile.id);
+            refreshServers();
+            setState((prev) => ({ ...prev, currentProfileIndex: nextIdx, currentIndex: 0 }));
+            refreshDaemonIfRunning("switching profile");
+          }
         }
         return;
       }
@@ -597,34 +606,21 @@ export function App({ onExit }: AppProps): React.ReactElement {
         return;
       }
 
-      // Space - Toggle server membership in current profile
+      // Space - Toggle server enable/disable
       if (input === " ") {
-        const { server, type } = getCurrentServer();
+        const { server } = getCurrentServer();
         if (!server) return;
 
-        const profiles = profileService.list();
-        const currentProfile = profiles[state.currentProfileIndex];
-        if (!currentProfile) return;
+        const result = server.disabled
+          ? configService.enableServer(server.id)
+          : configService.disableServer(server.id);
 
-        const profileData = profileService.getProfile(currentProfile.id);
-        if (!profileData) return;
-
-        const serverId = type === "remote" ? server.id : server.id;
-        const isIncludeAll = profileData.servers.length === 0 && profileData.remoteServers.length === 0;
-        const isMember = isIncludeAll ||
-          (type === "local" ? profileData.servers.includes(serverId) : profileData.remoteServers.includes(serverId));
-
-        if (isMember) {
-          if (isIncludeAll) {
-            profileService.makeExplicit(currentProfile.id);
-          }
-          profileService.removeServer(currentProfile.id, serverId);
-          showMessage(`Removed '${server.name}' from profile '${currentProfile.name}'`, "success");
-        } else {
-          profileService.addServer(currentProfile.id, serverId);
-          showMessage(`Added '${server.name}' to profile '${currentProfile.name}'`, "success");
+        if (result.success) {
+          showMessage(`${server.disabled ? "Enabled" : "Disabled"} '${server.name}'`, "success");
+          profileService.syncFromConfig();
+          refreshServers();
+          refreshDaemonIfRunning("toggling server");
         }
-        refreshDaemonIfRunning("toggling profile membership");
         return;
       }
 
@@ -731,6 +727,7 @@ export function App({ onExit }: AppProps): React.ReactElement {
         type={type}
         onBack={goBack}
         onSaved={(updatedServer) => {
+          profileService.syncFromConfig();
           refreshServers();
           refreshAuthStatus();
           showMessage(`Server '${updatedServer.name}' updated`, "success");
@@ -873,16 +870,6 @@ export function App({ onExit }: AppProps): React.ReactElement {
   const hasServers = localServers.length > 0 || remoteServers.length > 0;
   const profiles = profileService.list();
   const currentProfile = profiles[state.currentProfileIndex];
-  const profileData = currentProfile ? profileService.getProfile(currentProfile.id) : null;
-  const profileMemberIds = new Set<string>();
-  if (profileData) {
-    if (profileData.servers.length === 0 && profileData.remoteServers.length === 0) {
-      unifiedServers.forEach((u) => profileMemberIds.add(u.id));
-    } else {
-      profileData.servers.forEach((id) => profileMemberIds.add(id));
-      profileData.remoteServers.forEach((id) => profileMemberIds.add(`remote:${id}`));
-    }
-  }
   const port = configService.getPort();
   const toolFilters = configService.getToolFilters();
   const totalTokens = (() => {
@@ -897,12 +884,8 @@ export function App({ onExit }: AppProps): React.ReactElement {
       }
     };
 
-    localServers.forEach((server) => {
-      if (profileMemberIds.has(server.id)) accumulate(server.id);
-    });
-    remoteServers.forEach((server) => {
-      if (profileMemberIds.has(`remote:${server.id}`)) accumulate(`remote:${server.id}`);
-    });
+    localServers.forEach((server) => accumulate(server.id));
+    remoteServers.forEach((server) => accumulate(`remote:${server.id}`));
 
     return hasData ? total : null;
   })();
@@ -978,7 +961,6 @@ export function App({ onExit }: AppProps): React.ReactElement {
                     renderItem={(unified, idx) => {
                       const isCurrent = idx === state.currentIndex;
                       const { server, type, id } = unified;
-                      const isMember = profileMemberIds.has(id);
                       const isDisabled = server.disabled;
                       const filter = toolFilters[id];
                       const totalTools = filter?.allTools?.length ?? 0;
@@ -988,7 +970,6 @@ export function App({ onExit }: AppProps): React.ReactElement {
                       const tokenLabel = tokenTotal !== null ? `${formatTokens(tokenTotal)} tokens` : "— tokens";
                       const needsAuth = type === "remote" && state.serversNeedingAuth.has(server.id);
 
-                      const showCheck = isMember;
                       const nameColor = isCurrent ? theme.colors.highlightText : isDisabled ? theme.colors.disabled : undefined;
                       const arrowColor = isCurrent
                         ? theme.colors.serverArrowSelected
@@ -999,8 +980,8 @@ export function App({ onExit }: AppProps): React.ReactElement {
                       return (
                         <Box key={id} gap={1} paddingX={1}>
                           <Text color={arrowColor}>{isCurrent ? "→" : " "}</Text>
-                          <Text color={isDisabled ? theme.colors.warning : showCheck ? theme.colors.serverCheckEnabled : theme.colors.serverCheckDisabled}>
-                            {showCheck ? "[✓]" : "[ ]"}
+                          <Text color={isDisabled ? theme.colors.warning : theme.colors.serverCheckEnabled}>
+                            {isDisabled ? "[○]" : "[✓]"}
                           </Text>
                           <Text color={nameColor} bold={isCurrent}>
                             {server.name || server.id}

--- a/src/tui/screens/ProfilesScreen.tsx
+++ b/src/tui/screens/ProfilesScreen.tsx
@@ -381,7 +381,7 @@ export function ProfilesScreen({ onBack }: ProfilesScreenProps): React.ReactElem
       ) : (
         profiles.map((profile, idx) => {
           const isCurrent = idx === currentIndex;
-          const serverInfo = profile.includesAll ? "all servers" : `${profile.serverCount} server(s)`;
+          const serverInfo = `${profile.serverCount} server(s)`;
 
           return (
             <Box key={profile.id} flexDirection="column" marginBottom={1}>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,13 +55,7 @@ export type {
 } from "./client-strategy.types.js";
 
 // Profile types
-export type {
-  Profile,
-  ProfilesConfig,
-  ProfileListItem,
-  ProfileResult,
-  ProfileServers,
-} from "./profile.types.js";
+export type { Profile, ProfilesConfig, ProfileListItem, ProfileResult } from "./profile.types.js";
 
 // Settings types
 export type {

--- a/src/types/profile.types.ts
+++ b/src/types/profile.types.ts
@@ -3,15 +3,16 @@
  */
 
 import type { ToolFilters } from "./config.types.js";
+import type { LocalServer, RemoteServer } from "./server.types.js";
 
 /** Single profile definition */
 export interface Profile {
   /** Profile display name */
   name: string;
-  /** Local server IDs in this profile (empty = all) */
-  servers: string[];
-  /** Remote server IDs in this profile (empty = all) */
-  remoteServers: string[];
+  /** Local servers owned by this profile */
+  servers: LocalServer[];
+  /** Remote servers owned by this profile */
+  remoteServers: RemoteServer[];
   /** Per-profile tool filters (optional, for independent tool management) */
   toolFilters?: ToolFilters;
 }
@@ -34,18 +35,10 @@ export interface ProfileListItem {
   serverCount: number;
   /** Whether this is the active profile */
   isActive: boolean;
-  /** Whether profile includes all servers */
-  includesAll: boolean;
 }
 
 /** Profile operation result */
 export interface ProfileResult {
   success: boolean;
   error?: string;
-}
-
-/** Servers for a profile */
-export interface ProfileServers {
-  servers: import("./server.types.js").LocalServer[];
-  remoteServers: import("./server.types.js").RemoteServer[];
 }

--- a/tests/profiles.test.ts
+++ b/tests/profiles.test.ts
@@ -52,7 +52,7 @@ describe("ProfileService", () => {
       expect(profileService.getActiveProfile()).toBeDefined();
     });
 
-    it("should load existing profile", () => {
+    it("should load existing profile and migrate string IDs to objects", () => {
       fs.writeFileSync(
         path.join(testConfigDir, "profiles.json"),
         JSON.stringify({
@@ -69,7 +69,9 @@ describe("ProfileService", () => {
       expect(profileService.getActiveProfileId()).toBe("custom");
       const profile = profileService.getProfile("custom");
       expect(profile).toBeDefined();
-      expect(profile?.servers).toContain("server1");
+      // After migration, servers should be objects
+      expect(profile?.servers).toHaveLength(1);
+      expect(profile?.servers[0].id).toBe("server1");
     });
   });
 
@@ -88,7 +90,7 @@ describe("ProfileService", () => {
   });
 
   describe("create", () => {
-    it("should create a new profile", () => {
+    it("should create a new profile with empty server arrays", () => {
       profileService = new ProfileService();
 
       const result = profileService.create("test", "Test Profile");
@@ -97,6 +99,8 @@ describe("ProfileService", () => {
       const profile = profileService.getProfile("test");
       expect(profile).toBeDefined();
       expect(profile?.name).toBe("Test Profile");
+      expect(profile?.servers).toEqual([]);
+      expect(profile?.remoteServers).toEqual([]);
     });
 
     it("should fail when profile already exists", () => {
@@ -179,105 +183,79 @@ describe("ProfileService", () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain("not found");
     });
-  });
 
-  describe("addServer", () => {
-    it("should add local server to profile", () => {
+    it("should load profile servers into config.json when switching", () => {
       profileService = new ProfileService();
+      const configService = getConfigService();
 
-      profileService.create("test", "Test");
-      const result = profileService.addServer("test", "server1");
+      // Default profile was migrated to have all servers from config
+      // Create a new profile with specific servers
+      profileService.create("minimal", "Minimal");
+      const minimalProfile = profileService.getProfile("minimal");
+      expect(minimalProfile?.servers).toEqual([]);
 
-      expect(result.success).toBe(true);
+      // Switch to the minimal profile
+      profileService.use("minimal");
 
-      const profile = profileService.getProfile("test");
-      expect(profile?.servers).toContain("server1");
-    });
+      // Config should now have no servers (empty profile)
+      configService.reload();
+      expect(configService.getLocalServers()).toEqual([]);
+      expect(configService.getRemoteServers()).toEqual([]);
 
-    it("should add remote server to profile", () => {
-      profileService = new ProfileService();
+      // Switch back to default
+      profileService.use("default");
 
-      profileService.create("test", "Test");
-      const result = profileService.addServer("test", "remote1");
-
-      expect(result.success).toBe(true);
-
-      const profile = profileService.getProfile("test");
-      expect(profile?.remoteServers).toContain("remote1");
-    });
-
-    it("should fail when profile not found", () => {
-      profileService = new ProfileService();
-
-      const result = profileService.addServer("nonexistent", "server1");
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("Profile not found");
-    });
-
-    it("should fail when server not found", () => {
-      profileService = new ProfileService();
-
-      profileService.create("test", "Test");
-      const result = profileService.addServer("test", "nonexistent");
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("Server not found");
+      // Config should have the original servers
+      configService.reload();
+      expect(configService.getLocalServers()).toHaveLength(2);
+      expect(configService.getRemoteServers()).toHaveLength(1);
     });
   });
 
-  describe("removeServer", () => {
-    it("should remove server from profile", () => {
+  describe("syncFromConfig", () => {
+    it("should sync config.json servers into active profile", () => {
       profileService = new ProfileService();
+      const configService = getConfigService();
 
-      profileService.create("test", "Test");
-      profileService.addServer("test", "server1");
+      // Add a server to config.json
+      configService.addLocalServer({
+        id: "server3",
+        name: "Server 3",
+        command: "test",
+        args: [],
+      });
 
-      let profile = profileService.getProfile("test");
-      expect(profile?.servers).toContain("server1");
+      // Sync into active profile
+      profileService.syncFromConfig();
 
-      const result = profileService.removeServer("test", "server1");
-      expect(result.success).toBe(true);
-
-      profile = profileService.getProfile("test");
-      expect(profile?.servers).not.toContain("server1");
-    });
-
-    it("should fail when profile not found", () => {
-      profileService = new ProfileService();
-
-      const result = profileService.removeServer("nonexistent", "server1");
-      expect(result.success).toBe(false);
+      const profile = profileService.getActiveProfile();
+      expect(profile?.servers).toHaveLength(3);
+      expect(profile?.servers.some((s) => s.id === "server3")).toBe(true);
     });
   });
 
   describe("getServersForActiveProfile", () => {
-    it("should return all servers when profile has empty lists", () => {
+    it("should return profile servers directly", () => {
       profileService = new ProfileService();
 
+      // Default profile was migrated — should match what's in config.json
       const { servers, remoteServers } = profileService.getServersForActiveProfile();
-      expect(servers).toHaveLength(2);
-      expect(remoteServers).toHaveLength(1);
+      // Verify the servers are full objects (not string IDs)
+      expect(servers.length).toBeGreaterThan(0);
+      expect(servers[0]).toHaveProperty("id");
+      expect(servers[0]).toHaveProperty("command");
+      expect(remoteServers.length).toBeGreaterThan(0);
+      expect(remoteServers[0]).toHaveProperty("url");
     });
 
-    it("should return filtered servers when profile has specific servers", () => {
-      resetProfileService();
+    it("should return empty arrays for new empty profile", () => {
       profileService = new ProfileService();
 
-      // Use a unique profile name to avoid state from previous tests
-      profileService.create("filtered-test", "Filtered Test");
-      const addResult = profileService.addServer("filtered-test", "server1");
-      expect(addResult.success).toBe(true);
-
-      profileService.use("filtered-test");
-
-      const profile = profileService.getProfile("filtered-test");
-      // Verify profile state
-      expect(profile?.servers).toEqual(["server1"]);
-      expect(profile?.remoteServers).toEqual([]);
+      profileService.create("empty", "Empty");
+      profileService.use("empty");
 
       const { servers, remoteServers } = profileService.getServersForActiveProfile();
-      expect(servers).toHaveLength(1);
-      expect(servers[0].id).toBe("server1");
+      expect(servers).toHaveLength(0);
       expect(remoteServers).toHaveLength(0);
     });
   });
@@ -311,19 +289,18 @@ describe("ProfileService", () => {
   });
 
   describe("clone", () => {
-    it("should successfully clone a profile with new ID", () => {
+    it("should successfully clone a profile with servers", () => {
       profileService = new ProfileService();
 
-      profileService.create("source", "Source Profile");
-      profileService.addServer("source", "server1");
-
-      const result = profileService.clone("source", "target");
+      // Default profile has all servers from migration
+      const result = profileService.clone("default", "target");
       expect(result.success).toBe(true);
 
       const cloned = profileService.getProfile("target");
       expect(cloned).toBeDefined();
-      expect(cloned?.name).toBe("Source Profile (Copy)");
-      expect(cloned?.servers).toEqual(["server1"]);
+      expect(cloned?.name).toBe("Default (Copy)");
+      expect(cloned?.servers).toHaveLength(2);
+      expect(cloned?.servers[0].id).toBe("server1");
     });
 
     it("should clone with custom display name", () => {
@@ -336,16 +313,13 @@ describe("ProfileService", () => {
       expect(profileService.getProfile("target2")?.name).toBe("Custom Name");
     });
 
-    it("should deep clone servers and remoteServers arrays", () => {
+    it("should deep clone server objects", () => {
       profileService = new ProfileService();
 
-      profileService.create("source3", "Source");
-      profileService.addServer("source3", "server1");
-      profileService.addServer("source3", "remote1");
+      // Default profile has servers from migration
+      profileService.clone("default", "target3");
 
-      profileService.clone("source3", "target3");
-
-      const source = profileService.getProfile("source3");
+      const source = profileService.getProfile("default");
       const target = profileService.getProfile("target3");
 
       // Should be equal values
@@ -416,6 +390,39 @@ describe("ProfileService", () => {
       profileService.clone("source4", "target4");
 
       expect(profileService.getProfile("target4")?.name).toBe("My Profile (Copy)");
+    });
+  });
+
+  describe("migration", () => {
+    it("should migrate old string-ID profiles to embedded server objects", () => {
+      fs.writeFileSync(
+        path.join(testConfigDir, "profiles.json"),
+        JSON.stringify({
+          activeProfile: "default",
+          profiles: {
+            default: { name: "Default", servers: [], remoteServers: [] },
+            old: { name: "Old", servers: ["server1", "server2"], remoteServers: ["remote1"] },
+          },
+        })
+      );
+
+      profileService = new ProfileService();
+
+      const profile = profileService.getProfile("old");
+      expect(profile?.servers).toHaveLength(2);
+      expect(profile?.servers[0].id).toBe("server1");
+      expect(profile?.servers[0].name).toBe("Server 1");
+      expect(profile?.remoteServers).toHaveLength(1);
+      expect(profile?.remoteServers[0].id).toBe("remote1");
+    });
+
+    it("should populate empty profiles from config.json on first load", () => {
+      // Default profile with empty arrays should be populated from config
+      profileService = new ProfileService();
+
+      const profile = profileService.getActiveProfile();
+      expect(profile?.servers).toHaveLength(2);
+      expect(profile?.remoteServers).toHaveLength(1);
     });
   });
 });

--- a/tests/tui/App.test.tsx
+++ b/tests/tui/App.test.tsx
@@ -425,12 +425,6 @@ describe("Profile Switching", () => {
     vi.clearAllMocks();
     mockConfigService.getLocalServers.mockReturnValue(sampleLocalServers);
     mockConfigService.getRemoteServers.mockReturnValue(sampleRemoteServers);
-    // "dev" profile only includes server1 and remote1
-    mockProfileService.getProfile.mockImplementation((id: string) => {
-      if (id === "default") return { name: "Default", servers: [], remoteServers: [] };
-      if (id === "dev") return { name: "Development", servers: ["server1"], remoteServers: ["remote1"] };
-      return null;
-    });
     // Token data: server1=1000, server2=2000, server3=3000, remote1=500, remote2=700
     mockConfigService.getToolFilters.mockReturnValue({
       server1: { toolsData: { t1: { tokens: 1000 } }, disabledTools: [] },
@@ -441,21 +435,10 @@ describe("Profile Switching", () => {
     });
   });
 
-  it("should show all tokens when default profile (include all) is active", () => {
+  it("should show all tokens for active profile", () => {
     const { lastFrame } = render(<App />);
-    // Default profile includes all servers: 1000+2000+3000+500+700 = 7,200
+    // All servers in config: 1000+2000+3000+500+700 = 7,200
     expect(lastFrame()).toContain("7,200 tokens");
-  });
-
-  it("should show only profile member tokens after switching profile", async () => {
-    const { lastFrame, stdin } = render(<App />);
-
-    // Switch to "dev" profile (index 1) by pressing right arrow
-    stdin.write(KEYS.RIGHT);
-    await waitForStateUpdate();
-
-    // Dev profile includes server1 (1000) + remote1 (500) = 1,500
-    expect(lastFrame()).toContain("1,500 tokens");
   });
 
   it("should update header profile name when switching profiles", async () => {
@@ -469,27 +452,25 @@ describe("Profile Switching", () => {
     expect(lastFrame()).toContain("Development");
   });
 
-  it("should show all checkmarks for include-all profile", () => {
-    const { lastFrame } = render(<App />);
-
-    // Default profile includes all — every server should be checked
-    const frame = lastFrame();
-    const checkCount = (frame.match(/\[✓\]/g) || []).length;
-    expect(checkCount).toBe(sampleLocalServers.length + sampleRemoteServers.length);
-  });
-
-  it("should show partial checkmarks for explicit profile", async () => {
-    const { lastFrame, stdin } = render(<App />);
+  it("should call profileService.use when switching profiles", async () => {
+    const { stdin } = render(<App />);
 
     stdin.write(KEYS.RIGHT);
     await waitForStateUpdate();
 
-    // Dev profile has server1 + remote1 checked, others unchecked
+    expect(mockProfileService.use).toHaveBeenCalledWith("dev");
+  });
+
+  it("should show enabled/disabled status with checkmarks", () => {
+    const { lastFrame } = render(<App />);
+
     const frame = lastFrame();
+    // All enabled servers should have [✓], disabled ones should have [○]
     const checkedCount = (frame.match(/\[✓\]/g) || []).length;
-    const uncheckedCount = (frame.match(/\[ \]/g) || []).length;
-    expect(checkedCount).toBe(2); // server1 + remote1
-    expect(uncheckedCount).toBe(3); // server2, server3, remote2
+    const disabledCount = (frame.match(/\[○\]/g) || []).length;
+    // server2 is disabled in the sample data
+    expect(checkedCount).toBeGreaterThan(0);
+    expect(disabledCount + checkedCount).toBe(sampleLocalServers.length + sampleRemoteServers.length);
   });
 
   it("should cycle profiles with left arrow (wraps around)", async () => {
@@ -500,7 +481,6 @@ describe("Profile Switching", () => {
     await waitForStateUpdate();
 
     expect(lastFrame()).toContain("Development");
-    expect(lastFrame()).toContain("1,500 tokens");
   });
 
   it("should cycle profiles with right arrow (wraps around)", async () => {
@@ -513,36 +493,19 @@ describe("Profile Switching", () => {
     await waitForStateUpdate();
 
     expect(lastFrame()).toContain("Default");
-    expect(lastFrame()).toContain("7,200 tokens");
   });
 
-  it("should toggle profile membership with Space", async () => {
+  it("should toggle server enable/disable with Space", async () => {
     const { stdin } = render(<App />);
 
-    // Press space on first server (server1) while on default profile
+    // Press space on first server (server1) — should call enableServer or disableServer
     stdin.write(KEYS.SPACE);
     await waitForStateUpdate();
 
-    // Default profile is include-all, so Space should call makeExplicit then removeServer
-    expect(mockProfileService.makeExplicit).toHaveBeenCalledWith("default");
-    expect(mockProfileService.removeServer).toHaveBeenCalledWith("default", "server1");
-  });
-
-  it("should add server to explicit profile with Space", async () => {
-    const { stdin } = render(<App />);
-
-    // Switch to dev profile
-    stdin.write(KEYS.RIGHT);
-    await waitForStateUpdate();
-
-    // Navigate to server2 (index 1) which is NOT in dev profile
-    stdin.write(KEYS.DOWN);
-    await waitForStateUpdate();
-
-    stdin.write(KEYS.SPACE);
-    await waitForStateUpdate();
-
-    expect(mockProfileService.addServer).toHaveBeenCalledWith("dev", "server2");
+    // Should call disableServer since server1 is enabled
+    expect(mockConfigService.disableServer).toHaveBeenCalledWith("server1");
+    // Should sync to profile
+    expect(mockProfileService.syncFromConfig).toHaveBeenCalled();
   });
 });
 

--- a/tests/tui/App.test.tsx
+++ b/tests/tui/App.test.tsx
@@ -465,12 +465,11 @@ describe("Profile Switching", () => {
     const { lastFrame } = render(<App />);
 
     const frame = lastFrame();
-    // All enabled servers should have [✓], disabled ones should have [○]
+    // All enabled servers should have [✓], disabled ones show blank space
     const checkedCount = (frame.match(/\[✓\]/g) || []).length;
-    const disabledCount = (frame.match(/\[○\]/g) || []).length;
     // server2 is disabled in the sample data
     expect(checkedCount).toBeGreaterThan(0);
-    expect(disabledCount + checkedCount).toBe(sampleLocalServers.length + sampleRemoteServers.length);
+    expect(checkedCount).toBe(sampleLocalServers.filter(s => !s.disabled).length + sampleRemoteServers.length);
   });
 
   it("should cycle profiles with left arrow (wraps around)", async () => {

--- a/tests/tui/setup.ts
+++ b/tests/tui/setup.ts
@@ -98,21 +98,38 @@ export const mockClientService = {
 // Mock profile service
 export const mockProfileService = {
   list: vi.fn(() => [
-    { id: "default", name: "Default", isActive: true, includesAll: true, serverCount: 0 },
-    { id: "dev", name: "Development", isActive: false, includesAll: false, serverCount: 2 },
+    { id: "default", name: "Default", isActive: true, serverCount: 5 },
+    { id: "dev", name: "Development", isActive: false, serverCount: 2 },
   ]),
   create: vi.fn(() => ({ success: true })),
   delete: vi.fn(() => ({ success: true })),
   use: vi.fn(() => ({ success: true })),
   getActiveProfileId: vi.fn(() => "default"),
   getProfile: vi.fn((id: string) => {
-    if (id === "default") return { name: "Default", servers: [], remoteServers: [] };
-    if (id === "dev") return { name: "Development", servers: ["s1", "s2"], remoteServers: [] };
+    if (id === "default")
+      return {
+        name: "Default",
+        servers: [
+          { id: "server1", name: "Server One", command: "test", args: [] },
+          { id: "server2", name: "Server Two", command: "test", args: [], disabled: true },
+          { id: "server3", name: "Server Three", command: "test", args: [] },
+        ],
+        remoteServers: [
+          { id: "remote1", name: "Remote One", type: "http", url: "http://localhost" },
+          { id: "remote2", name: "Remote Two", type: "http", url: "http://localhost" },
+        ],
+      };
+    if (id === "dev")
+      return {
+        name: "Development",
+        servers: [{ id: "server1", name: "Server One", command: "test", args: [] }],
+        remoteServers: [
+          { id: "remote1", name: "Remote One", type: "http", url: "http://localhost" },
+        ],
+      };
     return null;
   }),
-  addServer: vi.fn(() => ({ success: true })),
-  removeServer: vi.fn(() => ({ success: true })),
-  makeExplicit: vi.fn(),
+  syncFromConfig: vi.fn(),
   rename: vi.fn(() => ({ success: true })),
   clone: vi.fn(() => ({ success: true })),
   reload: vi.fn(),


### PR DESCRIPTION
## Summary

- Profiles now own embedded server objects instead of referencing IDs from a global registry
- Space key toggles server enable/disable (was incorrectly toggling profile membership)
- Switching profiles (←→) loads that profile's servers into config.json
- Removed `profile add`/`profile remove` CLI commands (membership concept gone)
- Added `syncFromConfig()` to keep active profile in sync after server mutations
- Old string-ID profiles are auto-migrated to embedded objects on first load

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes  
- [x] `npm test` — 467 tests pass
- [ ] Manual TUI: Space toggles enabled/disabled
- [ ] Manual TUI: ←→ switches profiles and loads different servers
- [ ] Manual TUI: Add/delete server only affects current profile
- [ ] Manual TUI: New profile starts empty, clone copies servers