### PR TITLE
feat: detect package manager for version update banner

### DIFF
--- a/src/services/version.service.ts
+++ b/src/services/version.service.ts
@@ -11,6 +11,34 @@ interface VersionInfo {
   current: string;
   latest: string;
   hasUpdate: boolean;
+  installCommand: string;
+}
+
+function detectPackageManager(): string {
+  try {
+    const execPath = process.argv[1] || "";
+
+    if (execPath.includes(".bun/")) return "bun";
+    if (execPath.includes("/pnpm/") || execPath.includes("/pnpm-global/")) return "pnpm";
+    if (execPath.includes("/yarn/") || execPath.includes("/.yarn/")) return "yarn";
+  } catch {
+    // ignore
+  }
+
+  return "npm";
+}
+
+function getInstallCommand(pm: string): string {
+  switch (pm) {
+    case "bun":
+      return "bun install -g mcp-server-manager";
+    case "pnpm":
+      return "pnpm install -g mcp-server-manager";
+    case "yarn":
+      return "yarn global add mcp-server-manager";
+    default:
+      return "npm install -g mcp-server-manager";
+  }
 }
 
 class VersionService {
@@ -52,6 +80,8 @@ class VersionService {
    * Perform the actual version check against npm registry
    */
   private async performVersionCheck(): Promise<VersionInfo> {
+    const installCommand = getInstallCommand(detectPackageManager());
+
     try {
       const response = await fetch("https://registry.npmjs.org/mcp-server-manager/latest", {
         headers: {
@@ -71,14 +101,15 @@ class VersionService {
         current: VERSION,
         latest: latestVersion,
         hasUpdate,
+        installCommand,
       };
     } catch (error) {
       log.debug("Failed to check for updates:", error);
-      // Return no update available on error
       return {
         current: VERSION,
         latest: VERSION,
         hasUpdate: false,
+        installCommand,
       };
     }
   }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -78,7 +78,7 @@ interface AppState {
   confirmDelete?: { server: LocalServer | RemoteServer; type: "local" | "remote" }; // Server pending deletion confirmation
   editTarget?: { server: LocalServer | RemoteServer; type: "local" | "remote" };
   settingsInitialKey?: keyof Settings;
-  versionInfo?: { current: string; latest: string; hasUpdate: boolean };
+  versionInfo?: { current: string; latest: string; hasUpdate: boolean; installCommand: string };
 }
 
 interface AppProps {
@@ -947,6 +947,7 @@ export function App({ onExit }: AppProps): React.ReactElement {
           <VersionBanner
             currentVersion={state.versionInfo.current}
             latestVersion={state.versionInfo.latest}
+            installCommand={state.versionInfo.installCommand}
           />
         </Box>
       )}

--- a/src/tui/components/VersionBanner.tsx
+++ b/src/tui/components/VersionBanner.tsx
@@ -9,11 +9,13 @@ import { useTheme } from "../theme/index.js";
 interface VersionBannerProps {
   currentVersion: string;
   latestVersion: string;
+  installCommand: string;
 }
 
 export function VersionBanner({
   currentVersion,
   latestVersion,
+  installCommand,
 }: VersionBannerProps): React.ReactElement {
   const { theme } = useTheme();
 
@@ -36,7 +38,7 @@ export function VersionBanner({
       </Text>
       <Text dimColor>|</Text>
       <Text dimColor>Run:</Text>
-      <Text color={theme.colors.accent}>npm install -g mcp-server-manager</Text>
+      <Text color={theme.colors.accent}>{installCommand}</Text>
     </Box>
   );
 }


### PR DESCRIPTION
## What

Adds automatic package manager detection to the version update banner so users see the correct install command for their setup.

## Changes

- `version.service.ts`: Added `detectPackageManager()` (checks `process.argv[1]` path for bun/pnpm/yarn) and `getInstallCommand()` to build the right install command
- `VersionBanner.tsx`: Accepts `installCommand` as a prop instead of hardcoding `npm install -g mcp-server-manager`
- `App.tsx`: Passes `installCommand` from `versionInfo` down to `VersionBanner`