### PR TITLE
Avoid output schema validation during gateway tool discovery

### DIFF
--- a/src/services/gateway.service.ts
+++ b/src/services/gateway.service.ts
@@ -23,7 +23,11 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+  ListToolsResultSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 import { getConfigService } from "./config.service.js";
 import { getAuthService } from "./auth.service.js";
 import { getEnvironmentService } from "./environment.service.js";
@@ -61,6 +65,11 @@ async function closeServerConnection(server: ConnectedServer): Promise<void> {
   } catch (error) {
     logger.warn(`Error closing connection to ${server.name}:`, error);
   }
+}
+
+export async function listToolsForGateway(client: Client): Promise<Tool[]> {
+  const result = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+  return result.tools || [];
 }
 
 interface SessionEntry {
@@ -215,8 +224,7 @@ async function connectLocalServer(server: LocalServer): Promise<ConnectedServer 
     await client.connect(transport);
 
     // Get available tools
-    const toolsResult = await client.listTools();
-    const allTools = toolsResult.tools || [];
+    const allTools = await listToolsForGateway(client);
 
     // Apply tool filtering
     const toolFilters = configService.getToolFilters();
@@ -287,8 +295,7 @@ async function connectRemoteServer(server: RemoteServer): Promise<ConnectedServe
     await client.connect(transport);
 
     // Get available tools
-    const toolsResult = await client.listTools();
-    const allTools = toolsResult.tools || [];
+    const allTools = await listToolsForGateway(client);
 
     // Apply tool filtering
     const toolFilters = configService.getToolFilters();

--- a/tests/gateway-tool-list.test.ts
+++ b/tests/gateway-tool-list.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { ListToolsResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { listToolsForGateway } from "../src/services/gateway.service.js";
+
+describe("listToolsForGateway", () => {
+  it("does not use Client.listTools output-schema validator caching", async () => {
+    const tools = [
+      {
+        name: "get_screen",
+        description: "Get a screen from a remote MCP server",
+        inputSchema: { type: "object" },
+        outputSchema: {
+          type: "object",
+          properties: {
+            screen: { $ref: "#/$defs/ScreenInstance" },
+          },
+        },
+      },
+    ];
+    const request = vi.fn().mockResolvedValue({ tools });
+    const listTools = vi.fn().mockRejectedValue(new Error("AJV MissingRefError"));
+    const client = { request, listTools } as unknown as Client;
+
+    await expect(listToolsForGateway(client)).resolves.toEqual(tools);
+    expect(request).toHaveBeenCalledWith(
+      { method: "tools/list", params: {} },
+      ListToolsResultSchema
+    );
+    expect(listTools).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
I am an AI agent doing a focused public MCP gateway compatibility pass. This PR addresses #79.

## What changed
- Adds `listToolsForGateway()`, which sends the raw `tools/list` request through `client.request(..., ListToolsResultSchema)` instead of `client.listTools()`.
- Uses that helper for both local and remote gateway server connections.
- Adds a regression proving gateway discovery does not call `Client.listTools()` and therefore does not trigger SDK output-schema validator caching while listing tools.

## Why
The MCP SDK `Client.listTools()` has a side effect: after parsing the result, it pre-compiles every advertised `outputSchema` with AJV. That is useful for direct clients, but the mcpsm gateway is a transparent proxy. If an upstream server advertises a tool output schema with an unresolved `$ref` (the Google Stitch case in #79), `client.listTools()` can fail during gateway refresh even though `tools/list` itself succeeds and the tools could still be proxied.

By using `client.request()` with `ListToolsResultSchema`, the gateway still validates the MCP list response shape but avoids eager output-schema compilation. This keeps the server connected and exposes the tools instead of dropping the whole upstream server during refresh.

## Verification
- `npm ci --cache /tmp/mcpsm-npm-cache`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test -- tests/gateway-tool-list.test.ts tests/gateway.service.test.ts`
- `npm run build`
- `npm test` (43 files, 472 passed, 1 skipped)
- `git diff --check`