### PR TITLE
security: bind MCP gateway to loopback interface only

### DIFF
--- a/src/services/gateway.service.ts
+++ b/src/services/gateway.service.ts
@@ -674,7 +674,7 @@ export async function startGateway(
       };
 
       httpServer.once("error", onError);
-      httpServer.listen(port, () => {
+      httpServer.listen(port, "127.0.0.1", () => {
         httpServer.off("error", onError);
         logger.info(`Gateway listening on http://localhost:${port}`);
         resolve();


### PR DESCRIPTION
## Description

Binds the MCP gateway HTTP server to 127.0.0.1 instead of all network interfaces, preventing unauthenticated LAN-adjacent access to configured MCP tools. 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [X] Other (describe): Security enhancement

## Related Issues

Fixes #(issue number)

## Checklist

- [X] I've tested my changes locally
- [ ] I've updated documentation if needed
- [ ] I've added tests for new functionality
- [X] All tests pass (`npm test`)
- [X] Linting passes (`npm run lint`)

## Screenshots (if applicable)
