### PR TITLE
fix: harden local secret storage

### DIFF
--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -101,13 +101,19 @@ mcpsm auth refresh <server>
 
 ## Token Storage
 
-Credentials are stored in:
+OAuth tokens are stored as local JSON in:
 
-- **macOS**: Keychain
-- **Linux**: Secret Service (via libsecret)
-- **Windows**: Credential Manager
+- `~/.mcp-manager/oauth-tokens.json`
 
-Fallback: Encrypted file in `~/.mcp-manager/`
+On macOS and Linux, mcpsm creates the config directory with `0700`
+permissions and writes OAuth token files with `0600` permissions. Existing
+token files with broader permissions are tightened when mcpsm loads or saves
+them.
+
+Older versions used `~/.mcpsm/oauth-tokens.json`. If that legacy file exists
+and the new token file is absent, mcpsm copies the tokens into
+`~/.mcp-manager/oauth-tokens.json` and leaves the legacy file in place with
+private permissions.
 
 ---
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -17,6 +17,16 @@ All mcpsm settings are stored in `~/.mcp-manager/`:
 | `profiles.json`     | Server profiles (grouping by context)     |
 | `clients.json`      | Client connection state cache             |
 
+On macOS and Linux, mcpsm creates `~/.mcp-manager/` with private directory
+permissions (`0700`) and writes mcpsm-owned JSON files with private file
+permissions (`0600`). Existing files with broader permissions are tightened
+when mcpsm loads or saves them.
+
+`config.json` can contain secrets such as local server environment variables,
+remote bearer tokens, custom headers, and OAuth client secrets. OAuth runtime
+tokens are stored separately in `~/.mcp-manager/oauth-tokens.json` with the same
+private file permissions.
+
 ## config.json
 
 Main configuration file containing server definitions:

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -28,6 +28,14 @@ import type {
 } from "../types/index.js";
 import { createLogger } from "../shared/logger.js";
 import { renderCallbackPage } from "./auth-callback.html.js";
+import {
+  applyPrivateMode,
+  ensurePrivateDirectory,
+  PRIVATE_DIR_MODE,
+  protectExistingPrivateFile,
+  writePrivateFile,
+  writePrivateJsonFile,
+} from "../shared/secure-storage.js";
 
 const log = createLogger("AuthService");
 
@@ -63,6 +71,7 @@ const PROACTIVE_RETRY_DELAYS_MS = [30_000, 60_000, 120_000, 240_000, 480_000]; /
 
 export class AuthService {
   private configDir: string;
+  private legacyConfigDirs: string[];
   private tokensPath: string;
   private pendingAuthPath: string;
   private tokens: Map<string, StoredOAuthTokens>;
@@ -78,10 +87,26 @@ export class AuthService {
   private refreshRetryCounts: Map<string, number> = new Map();
 
   constructor(configDir?: string) {
+    const homeDir = process.env.HOME || process.env.USERPROFILE || "";
+    const defaultConfigDir = path.join(homeDir, ".mcp-manager");
+    const defaultLegacyConfigDir = path.join(homeDir, ".mcpsm");
+    const shouldUseDefaultPaths =
+      !configDir && !process.env.MCP_MANAGER_CONFIG_DIR && !process.env.MCPSM_CONFIG_DIR;
+    const shouldMigrateLegacyEnv = !configDir && !!process.env.MCP_MANAGER_CONFIG_DIR;
+
     this.configDir =
       configDir ||
+      process.env.MCP_MANAGER_CONFIG_DIR ||
       process.env.MCPSM_CONFIG_DIR ||
-      path.join(process.env.HOME || process.env.USERPROFILE || "", ".mcpsm");
+      defaultConfigDir;
+    this.legacyConfigDirs = Array.from(
+      new Set(
+        [
+          shouldMigrateLegacyEnv ? process.env.MCPSM_CONFIG_DIR : undefined,
+          shouldUseDefaultPaths ? defaultLegacyConfigDir : undefined,
+        ].filter(Boolean) as string[]
+      )
+    );
 
     this.tokensPath = path.join(this.configDir, TOKENS_FILE);
     this.pendingAuthPath = path.join(this.configDir, PENDING_AUTH_FILE);
@@ -89,14 +114,32 @@ export class AuthService {
     this.pendingAuths = new Map();
 
     this.ensureConfigDir();
+    this.migrateLegacyTokens();
     this.loadTokens();
     this.loadPendingAuths();
   }
 
   /** Ensure config directory exists */
   private ensureConfigDir(): void {
-    if (!fs.existsSync(this.configDir)) {
-      fs.mkdirSync(this.configDir, { recursive: true });
+    ensurePrivateDirectory(this.configDir);
+  }
+
+  /** Move legacy OAuth tokens into the main config directory when no new file exists yet */
+  private migrateLegacyTokens(): void {
+    for (const legacyConfigDir of this.legacyConfigDirs) {
+      if (legacyConfigDir === this.configDir) continue;
+
+      const legacyTokensPath = path.join(legacyConfigDir, TOKENS_FILE);
+
+      if (fs.existsSync(legacyConfigDir)) {
+        applyPrivateMode(legacyConfigDir, PRIVATE_DIR_MODE);
+      }
+
+      protectExistingPrivateFile(legacyTokensPath);
+
+      if (!fs.existsSync(this.tokensPath) && fs.existsSync(legacyTokensPath)) {
+        writePrivateFile(this.tokensPath, fs.readFileSync(legacyTokensPath, "utf8"));
+      }
     }
   }
 
@@ -104,6 +147,7 @@ export class AuthService {
   private loadTokens(): void {
     try {
       if (fs.existsSync(this.tokensPath)) {
+        protectExistingPrivateFile(this.tokensPath);
         const data = fs.readFileSync(this.tokensPath, "utf8");
         const parsed = JSON.parse(data) as Record<string, StoredOAuthTokens>;
         this.tokens = new Map(Object.entries(parsed));
@@ -118,7 +162,7 @@ export class AuthService {
   private saveTokens(): void {
     try {
       const data = Object.fromEntries(this.tokens);
-      fs.writeFileSync(this.tokensPath, JSON.stringify(data, null, 2));
+      writePrivateJsonFile(this.tokensPath, data);
     } catch (error) {
       log.debug("Failed to save OAuth tokens:", error);
     }
@@ -128,6 +172,7 @@ export class AuthService {
   private loadPendingAuths(): void {
     try {
       if (fs.existsSync(this.pendingAuthPath)) {
+        protectExistingPrivateFile(this.pendingAuthPath);
         const data = fs.readFileSync(this.pendingAuthPath, "utf8");
         const parsed = JSON.parse(data) as Record<string, PendingAuthorization>;
 
@@ -149,7 +194,7 @@ export class AuthService {
   private savePendingAuths(): void {
     try {
       const data = Object.fromEntries(this.pendingAuths);
-      fs.writeFileSync(this.pendingAuthPath, JSON.stringify(data, null, 2));
+      writePrivateJsonFile(this.pendingAuthPath, data);
     } catch (error) {
       log.debug("Failed to save pending authorizations:", error);
     }

--- a/src/services/config/config.repository.ts
+++ b/src/services/config/config.repository.ts
@@ -2,6 +2,11 @@ import fs from "fs";
 import path from "path";
 import type { AppConfig, ConfigPaths, SelectionState, ToolFilters } from "../../types/index.js";
 import { createLogger } from "../../shared/logger.js";
+import {
+  ensurePrivateDirectory,
+  protectExistingPrivateFile,
+  writePrivateJsonFile,
+} from "../../shared/secure-storage.js";
 
 const log = createLogger("ConfigRepository");
 
@@ -53,7 +58,7 @@ export class ConfigRepository {
   }
 
   saveConfig(): void {
-    fs.writeFileSync(this.paths.configPath, JSON.stringify(this.config, null, 2));
+    writePrivateJsonFile(this.paths.configPath, this.config);
   }
 
   updateConfig(mutator: (config: AppConfig) => void): void {
@@ -66,7 +71,7 @@ export class ConfigRepository {
   }
 
   saveToolFilters(): void {
-    fs.writeFileSync(this.paths.toolFiltersPath, JSON.stringify(this.toolFilters, null, 2));
+    writePrivateJsonFile(this.paths.toolFiltersPath, this.toolFilters);
   }
 
   updateToolFilters(mutator: (filters: ToolFilters) => void): void {
@@ -80,18 +85,17 @@ export class ConfigRepository {
 
   saveSelectionState(state: SelectionState): void {
     this.selectionState = state;
-    fs.writeFileSync(this.paths.selectionStatePath, JSON.stringify(state, null, 2));
+    writePrivateJsonFile(this.paths.selectionStatePath, state);
   }
 
   private ensureConfigDir(): void {
-    if (!fs.existsSync(this.configDir)) {
-      fs.mkdirSync(this.configDir, { recursive: true });
-    }
+    ensurePrivateDirectory(this.configDir);
   }
 
   private loadConfig(): AppConfig {
     try {
       if (fs.existsSync(this.paths.configPath)) {
+        protectExistingPrivateFile(this.paths.configPath);
         const data = fs.readFileSync(this.paths.configPath, "utf8");
         const parsed = JSON.parse(data) as Partial<AppConfig>;
 
@@ -112,13 +116,14 @@ export class ConfigRepository {
     }
 
     const fallback = { ...DEFAULT_CONFIG };
-    fs.writeFileSync(this.paths.configPath, JSON.stringify(fallback, null, 2));
+    writePrivateJsonFile(this.paths.configPath, fallback);
     return fallback;
   }
 
   private loadToolFilters(): ToolFilters {
     try {
       if (fs.existsSync(this.paths.toolFiltersPath)) {
+        protectExistingPrivateFile(this.paths.toolFiltersPath);
         const data = fs.readFileSync(this.paths.toolFiltersPath, "utf8");
         return JSON.parse(data) as ToolFilters;
       }
@@ -131,6 +136,7 @@ export class ConfigRepository {
   private loadSelectionState(): SelectionState {
     try {
       if (fs.existsSync(this.paths.selectionStatePath)) {
+        protectExistingPrivateFile(this.paths.selectionStatePath);
         const data = fs.readFileSync(this.paths.selectionStatePath, "utf8");
         return JSON.parse(data) as SelectionState;
       }

--- a/src/services/gateway.service.ts
+++ b/src/services/gateway.service.ts
@@ -829,7 +829,7 @@ export async function refreshGateway(
         };
 
         server.once("error", onError);
-        server.listen(configuredPort, () => {
+        server.listen(configuredPort, "127.0.0.1", () => {
           server.off("error", onError);
           resolve();
         });

--- a/src/services/profile.service.ts
+++ b/src/services/profile.service.ts
@@ -12,6 +12,7 @@ import type {
 } from "../types/index.js";
 import { getConfigService } from "./config.service.js";
 import { createLogger } from "../shared/logger.js";
+import { protectExistingPrivateFile, writePrivateJsonFile } from "../shared/secure-storage.js";
 
 const log = createLogger("ProfileService");
 
@@ -42,6 +43,7 @@ export class ProfileService {
   private load(): ProfilesConfig {
     try {
       if (fs.existsSync(this.profilesPath)) {
+        protectExistingPrivateFile(this.profilesPath);
         const data = fs.readFileSync(this.profilesPath, "utf8");
         const parsed = JSON.parse(data) as Partial<ProfilesConfig>;
         return { ...DEFAULT_PROFILES, ...parsed };
@@ -54,7 +56,7 @@ export class ProfileService {
 
   /** Save profiles to file */
   private save(): void {
-    fs.writeFileSync(this.profilesPath, JSON.stringify(this.profiles, null, 2));
+    writePrivateJsonFile(this.profilesPath, this.profiles);
   }
 
   /** Get active profile ID */

--- a/src/services/settings.service.ts
+++ b/src/services/settings.service.ts
@@ -6,6 +6,7 @@ import fs from "fs";
 import type { Settings, SettingInfo, SettingsInfo, SettingResult } from "../types/index.js";
 import { getConfigService } from "./config.service.js";
 import { createLogger } from "../shared/logger.js";
+import { protectExistingPrivateFile, writePrivateJsonFile } from "../shared/secure-storage.js";
 
 const log = createLogger("SettingsService");
 
@@ -47,6 +48,7 @@ export class SettingsService {
   private load(): Settings {
     try {
       if (fs.existsSync(this.settingsPath)) {
+        protectExistingPrivateFile(this.settingsPath);
         const data = fs.readFileSync(this.settingsPath, "utf8");
         const parsed = JSON.parse(data) as Partial<Settings>;
         return { ...DEFAULT_SETTINGS, ...parsed };
@@ -59,7 +61,7 @@ export class SettingsService {
 
   /** Save settings to file */
   private save(): void {
-    fs.writeFileSync(this.settingsPath, JSON.stringify(this.settings, null, 2));
+    writePrivateJsonFile(this.settingsPath, this.settings);
   }
 
   /** Get all settings */

--- a/src/shared/secure-storage.ts
+++ b/src/shared/secure-storage.ts
@@ -1,0 +1,33 @@
+import fs from "fs";
+import path from "path";
+
+export const PRIVATE_DIR_MODE = 0o700;
+export const PRIVATE_FILE_MODE = 0o600;
+
+const supportsPosixModes = process.platform !== "win32";
+
+export function applyPrivateMode(filePath: string, mode: number): void {
+  if (!supportsPosixModes) return;
+  fs.chmodSync(filePath, mode);
+}
+
+export function ensurePrivateDirectory(dirPath: string): void {
+  fs.mkdirSync(dirPath, { recursive: true, mode: PRIVATE_DIR_MODE });
+  applyPrivateMode(dirPath, PRIVATE_DIR_MODE);
+}
+
+export function writePrivateFile(filePath: string, contents: string): void {
+  ensurePrivateDirectory(path.dirname(filePath));
+  fs.writeFileSync(filePath, contents, { mode: PRIVATE_FILE_MODE });
+  applyPrivateMode(filePath, PRIVATE_FILE_MODE);
+}
+
+export function writePrivateJsonFile(filePath: string, value: unknown): void {
+  writePrivateFile(filePath, JSON.stringify(value, null, 2));
+}
+
+export function protectExistingPrivateFile(filePath: string): void {
+  if (fs.existsSync(filePath)) {
+    applyPrivateMode(filePath, PRIVATE_FILE_MODE);
+  }
+}

--- a/tests/auth.service.test.ts
+++ b/tests/auth.service.test.ts
@@ -3,13 +3,26 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 import { AuthService, resetAuthService } from "../src/services/auth.service.js";
-import type { RemoteServer, StoredOAuthTokens } from "../src/types/index.js";
+import type { PendingAuthorization, RemoteServer, StoredOAuthTokens } from "../src/types/index.js";
+
+const fileMode = (filePath: string): number => fs.statSync(filePath).mode & 0o777;
+
+type AuthServiceWithPendingInternals = AuthService & {
+  pendingAuths: Map<string, PendingAuthorization>;
+  savePendingAuths: () => void;
+};
 
 describe("AuthService", () => {
   let configDir: string;
   let service: AuthService;
+  let originalMcpManagerConfigDir: string | undefined;
+  let originalMcpsmConfigDir: string | undefined;
 
   beforeEach(() => {
+    originalMcpManagerConfigDir = process.env.MCP_MANAGER_CONFIG_DIR;
+    originalMcpsmConfigDir = process.env.MCPSM_CONFIG_DIR;
+    delete process.env.MCP_MANAGER_CONFIG_DIR;
+    delete process.env.MCPSM_CONFIG_DIR;
     configDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcpsm-auth-"));
     service = new AuthService(configDir);
   });
@@ -19,6 +32,16 @@ describe("AuthService", () => {
     vi.unstubAllGlobals();
     if (fs.existsSync(configDir)) {
       fs.rmSync(configDir, { recursive: true, force: true });
+    }
+    if (originalMcpManagerConfigDir === undefined) {
+      delete process.env.MCP_MANAGER_CONFIG_DIR;
+    } else {
+      process.env.MCP_MANAGER_CONFIG_DIR = originalMcpManagerConfigDir;
+    }
+    if (originalMcpsmConfigDir === undefined) {
+      delete process.env.MCPSM_CONFIG_DIR;
+    } else {
+      process.env.MCPSM_CONFIG_DIR = originalMcpsmConfigDir;
     }
   });
 
@@ -49,6 +72,137 @@ describe("AuthService", () => {
     expect(reloaded.getTokenPreview("srv")).toBe("toke...alue");
     expect(reloaded.getToken("srv")?.refreshToken).toBe("refresh-token");
     expect(reloaded.isTokenExpired("srv")).toBe(false);
+  });
+
+  it("stores OAuth tokens and pending auth state with private permissions", async () => {
+    if (process.platform === "win32") return;
+
+    service.saveTokensForServer("srv", {
+      accessToken: "token-value",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+    });
+    const internals = service as unknown as AuthServiceWithPendingInternals;
+    internals.pendingAuths.set("state", {
+      serverId: "remote1",
+      serverUrl: "https://api.example.com",
+      pkce: {
+        codeVerifier: "verifier",
+        codeChallenge: "challenge",
+        codeChallengeMethod: "S256",
+      },
+      state: "state",
+      redirectUri: "http://127.0.0.1:8400/callback",
+      authorizationEndpoint: "https://auth.example.com/authorize",
+      tokenEndpoint: "https://auth.example.com/token",
+      clientId: "client",
+      scopes: ["tools.read"],
+      createdAt: Date.now(),
+    });
+    internals.savePendingAuths();
+
+    const paths = service.getStoragePaths();
+    expect(fileMode(paths.configDir)).toBe(0o700);
+    expect(fileMode(paths.tokensPath)).toBe(0o600);
+    expect(fileMode(paths.pendingAuthPath)).toBe(0o600);
+  });
+
+  it("uses MCP_MANAGER_CONFIG_DIR for default OAuth token storage", () => {
+    const envConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcpsm-auth-env-"));
+    try {
+      resetAuthService();
+      process.env.MCP_MANAGER_CONFIG_DIR = envConfigDir;
+
+      const envService = new AuthService();
+
+      expect(envService.getStoragePaths().tokensPath).toBe(
+        path.join(envConfigDir, "oauth-tokens.json")
+      );
+    } finally {
+      fs.rmSync(envConfigDir, { recursive: true, force: true });
+    }
+  });
+
+  it("migrates legacy OAuth tokens into the main config directory", () => {
+    if (process.platform === "win32") return;
+
+    const mainConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcpsm-auth-main-"));
+    const legacyConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcpsm-auth-legacy-"));
+    const legacyTokensPath = path.join(legacyConfigDir, "oauth-tokens.json");
+    const legacyTokens = {
+      srv: {
+        accessToken: "legacy-token",
+        refreshToken: "legacy-refresh",
+        tokenType: "Bearer",
+      },
+    };
+
+    try {
+      fs.writeFileSync(legacyTokensPath, JSON.stringify(legacyTokens), { mode: 0o644 });
+      fs.chmodSync(legacyConfigDir, 0o755);
+      fs.chmodSync(legacyTokensPath, 0o644);
+
+      resetAuthService();
+      process.env.MCP_MANAGER_CONFIG_DIR = mainConfigDir;
+      process.env.MCPSM_CONFIG_DIR = legacyConfigDir;
+
+      const migrated = new AuthService();
+      const paths = migrated.getStoragePaths();
+
+      expect(paths.tokensPath).toBe(path.join(mainConfigDir, "oauth-tokens.json"));
+      expect(migrated.getToken("srv")?.accessToken).toBe("legacy-token");
+      expect(JSON.parse(fs.readFileSync(paths.tokensPath, "utf8"))).toEqual(legacyTokens);
+      expect(fileMode(paths.tokensPath)).toBe(0o600);
+      expect(fileMode(legacyConfigDir)).toBe(0o700);
+      expect(fileMode(legacyTokensPath)).toBe(0o600);
+    } finally {
+      fs.rmSync(mainConfigDir, { recursive: true, force: true });
+      fs.rmSync(legacyConfigDir, { recursive: true, force: true });
+    }
+  });
+
+  it("migrates default legacy OAuth tokens into the default main config directory", () => {
+    if (process.platform === "win32") return;
+
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcpsm-auth-home-"));
+    const mainConfigDir = path.join(homeDir, ".mcp-manager");
+    const legacyConfigDir = path.join(homeDir, ".mcpsm");
+    const legacyTokensPath = path.join(legacyConfigDir, "oauth-tokens.json");
+    const originalHome = process.env.HOME;
+    const legacyTokens = {
+      srv: {
+        accessToken: "default-legacy-token",
+        tokenType: "Bearer",
+      },
+    };
+
+    try {
+      fs.mkdirSync(legacyConfigDir, { recursive: true, mode: 0o755 });
+      fs.writeFileSync(legacyTokensPath, JSON.stringify(legacyTokens), { mode: 0o644 });
+      fs.chmodSync(legacyConfigDir, 0o755);
+      fs.chmodSync(legacyTokensPath, 0o644);
+      resetAuthService();
+      process.env.HOME = homeDir;
+      delete process.env.MCP_MANAGER_CONFIG_DIR;
+      delete process.env.MCPSM_CONFIG_DIR;
+
+      const migrated = new AuthService();
+      const paths = migrated.getStoragePaths();
+
+      expect(paths.tokensPath).toBe(path.join(mainConfigDir, "oauth-tokens.json"));
+      expect(migrated.getToken("srv")?.accessToken).toBe("default-legacy-token");
+      expect(fileMode(mainConfigDir)).toBe(0o700);
+      expect(fileMode(paths.tokensPath)).toBe(0o600);
+      expect(fileMode(legacyConfigDir)).toBe(0o700);
+      expect(fileMode(legacyTokensPath)).toBe(0o600);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
   });
 
   it("refreshes tokens using the refresh_token grant", async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,6 +7,8 @@ import { ConfigService, resetConfigService } from "../src/services/config.servic
 // Test directory setup
 const testConfigDir = path.join(os.tmpdir(), "mcpsm-config-test-" + Date.now());
 
+const fileMode = (filePath: string): number => fs.statSync(filePath).mode & 0o777;
+
 describe("ConfigService", () => {
   let configService: ConfigService;
 
@@ -41,6 +43,36 @@ describe("ConfigService", () => {
 
       const paths = configService.getPaths();
       expect(fs.existsSync(paths.configPath)).toBe(true);
+    });
+
+    it("creates the config directory and config file with private permissions", () => {
+      if (process.platform === "win32") return;
+
+      fs.rmSync(testConfigDir, { recursive: true, force: true });
+      const originalUmask = process.umask(0o022);
+      try {
+        configService = new ConfigService(testConfigDir);
+      } finally {
+        process.umask(originalUmask);
+      }
+
+      const paths = configService.getPaths();
+      expect(fileMode(paths.configDir)).toBe(0o700);
+      expect(fileMode(paths.configPath)).toBe(0o600);
+    });
+
+    it("repairs existing insecure config directory and file permissions", () => {
+      if (process.platform === "win32") return;
+
+      const configPath = path.join(testConfigDir, "config.json");
+      fs.chmodSync(testConfigDir, 0o755);
+      fs.writeFileSync(configPath, JSON.stringify({ port: 8850 }), { mode: 0o644 });
+      fs.chmodSync(configPath, 0o644);
+
+      configService = new ConfigService(testConfigDir);
+
+      expect(fileMode(testConfigDir)).toBe(0o700);
+      expect(fileMode(configPath)).toBe(0o600);
     });
 
     it("should load existing config", () => {

--- a/tests/gateway.service.test.ts
+++ b/tests/gateway.service.test.ts
@@ -57,7 +57,7 @@ describe("GatewayService", () => {
 
   it("re-binds the HTTP server when port changes on refresh", async () => {
     const close = vi.fn((cb: (err?: Error | null) => void) => cb(null));
-    const listen = vi.fn((_port: number, cb: () => void) => cb());
+    const listen = vi.fn((_port: number, _host: string, cb: () => void) => cb());
     const mockServer = {
       close,
       listen,
@@ -81,7 +81,7 @@ describe("GatewayService", () => {
 
     expect(result.success).toBe(true);
     expect(close).toHaveBeenCalled();
-    expect(listen).toHaveBeenCalledWith(4000, expect.any(Function));
+    expect(listen).toHaveBeenCalledWith(4000, "127.0.0.1", expect.any(Function));
     expect(getGatewayStatus().port).toBe(4000);
     expect(mockAuthService.reload).toHaveBeenCalled();
     expect(mockConfigService.reload).toHaveBeenCalled();


### PR DESCRIPTION
## Description

Hardens MCPSM-owned local storage by writing config, settings, profiles, OAuth tokens, and pending auth JSON through private `0700`/`0600` helpers that also repair existing loose permissions. Aligns OAuth token storage under `~/.mcp-manager` with a non-destructive migration from legacy `~/.mcpsm` tokens, fixes refresh-time gateway rebinding to stay on `127.0.0.1`, and updates docs to remove unsupported keychain/encrypted-storage claims.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactoring
- [ ] Other (describe):

## Related Issues

N/A

## Checklist

- [x] I've tested my changes locally
- [x] I've updated documentation if needed
- [x] I've added tests for new functionality
- [x] All tests pass (`npm test`)
- [x] Linting passes (`npm run lint`)

## Screenshots (if applicable)

N/A
