### PR TITLE
Add Xquik remote MCP example

### DIFF
--- a/docs/guide/advanced-examples.md
+++ b/docs/guide/advanced-examples.md
@@ -46,6 +46,15 @@ mcpsm add stripe \
   --token "sk_live_..."
 ```
 
+### Xquik Remote MCP with Bearer Token
+
+```bash
+mcpsm add xquik \
+  --type http \
+  --url "https://xquik.com/mcp" \
+  --token "<XQUIK_API_KEY>"
+```
+
 ### SSE Server with OAuth
 
 ```bash


### PR DESCRIPTION
## Summary
- Add Xquik as a remote MCP server example.
- Use the existing HTTP token setup path for bearer-token authentication.

## Validation
- Git diff whitespace check passed.
